### PR TITLE
Fix Dash Version Precision

### DIFF
--- a/Dash/0.13.0/linuxamd64.Dockerfile
+++ b/Dash/0.13.0/linuxamd64.Dockerfile
@@ -4,7 +4,7 @@ RUN set -ex \
 	&& apt-get update \
 	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget
 
-ENV DASH_VERSION 0.13.0.0
+ENV DASH_VERSION 0.13.0
 ENV DASH_URL https://github.com/dashpay/dash/releases/download/v0.13.0.0/dashcore-0.13.0.0-x86_64-linux-gnu.tar.gz
 ENV DASH_SHA256 99b4309c7f53b2a93d4b60a45885000b88947af2f329e24ca757ff8cf882ab18
 ENV DASH_ASC_URL https://github.com/dashpay/dash/releases/download/v0.13.0.0/SHA256SUMS.asc

--- a/Dash/0.13.0/linuxarm32v7.Dockerfile
+++ b/Dash/0.13.0/linuxarm32v7.Dockerfile
@@ -5,7 +5,7 @@ RUN set -ex \
 	&& apt-get update \
 	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget
 
-ENV DASH_VERSION 0.13.0.0
+ENV DASH_VERSION 0.13.0
 ENV DASH_URL https://github.com/dashpay/dash/releases/download/v0.13.0.0/dashcore-0.13.0.0-arm-linux-gnueabihf.tar.gz
 ENV DASH_SHA256 f499684cdef879129b75681e040452816929d8db77def6faa0e1f0718d0d586f
 ENV DASH_ASC_URL https://github.com/dashpay/dash/releases/download/v0.13.0.0/SHA256SUMS.asc

--- a/Dash/0.13.0/linuxarm64v8.Dockerfile
+++ b/Dash/0.13.0/linuxarm64v8.Dockerfile
@@ -5,7 +5,7 @@ RUN set -ex \
 	&& apt-get update \
 	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget
 
-ENV DASH_VERSION 0.13.0.0
+ENV DASH_VERSION 0.13.0
 ENV DASH_URL https://github.com/dashpay/dash/releases/download/v0.13.0.0/dashcore-0.13.0.0-aarch64-linux-gnu.tar.gz
 ENV DASH_SHA256 48daaa2df45c0b9b44e3ed9d9ecbf184a46c3c40422417a6ab41162b04013ebb
 ENV DASH_ASC_URL https://github.com/dashpay/dash/releases/download/v0.13.0.0/SHA256SUMS.asc


### PR DESCRIPTION
This fixes a build issue related to the following command:

tar -xzvf dash.tar.gz -C /tmp/bin --strip-components=2 "dashcore-$DASH_VERSION/bin/dash-cli" "dashcore-$DASH_VERSION/bin/dashd"

