### PR TITLE
[FIX]  Entrypoint.sh references bitcoin.conf and fails daemon start

### DIFF
--- a/Litecoin/0.17.1/docker-entrypoint.sh
+++ b/Litecoin/0.17.1/docker-entrypoint.sh
@@ -15,7 +15,7 @@ if [[ "$1" == "litecoin-cli" || "$1" == "litecoin-tx" || "$1" == "litecoind" || 
 		CONFIG_PREFIX=$'mainnet=1\n[main]'
 	fi
 
-	cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
+	cat <<-EOF > "$BITCOIN_DATA/litecoin.conf"
 	${CONFIG_PREFIX}
 	printtoconsole=1
 	rpcallowip=::/0


### PR DESCRIPTION
BTCPayServer will not sync Litecoin as the container will not start, with error:
```
root@ip-***-***-***-***~/btcpayserver-docker# docker run -it btcpayserver/litecoin:0.17.1
chown: cannot access '/data/litecoin.conf': No such file or directory
```
After updating tag in /Generated/docker-compose.generated.yml to fixed version `aaronmboyd/btcpayserver-litecoin:0.17.1` , Litecoin node is now syncing:

```
root@ip-***-***-***-***:~/btcpayserver-docker# docker logs 4a022230e5b4
2019-05-22T14:33:53Z Litecoin Core version v0.17.1 (release build)
2019-05-22T14:33:53Z InitParameterInteraction: parameter interaction: -whitelistforcerelay=1 -> setting -whitelistrelay=1
2019-05-22T14:33:53Z Assuming ancestors of block a601455787cb65ffc325dda4751a99cf01d1567799ec4b04f45bb05f9ef0cbde have valid signatures.
2019-05-22T14:33:53Z Setting nMinimumChainWork=0000000000000000000000000000000000000000000001488d32719b8eb30150
2019-05-22T14:33:53Z Using the 'sse4(1way),sse41(4way),avx2(8way)' SHA256 implementation
2019-05-22T14:33:53Z Using RdRand as an additional entropy source
2019-05-22T14:33:53Z Default data directory /home/bitcoin/.litecoin
2019-05-22T14:33:53Z Using data directory /home/bitcoin/.litecoin
2019-05-22T14:33:53Z Using config file /home/bitcoin/.litecoin/litecoin.conf
2019-05-22T14:33:53Z Using at most 125 automatic connections (1048576 file descriptors available)
2019-05-22T14:33:53Z Using 16 MiB out of 32/2 requested for signature cache, able to store 524288 elements
2019-05-22T14:33:53Z Using 16 MiB out of 32/2 requested for script execution cache, able to store 524288 elements
```
