### PR TITLE
Add in block.txt to block malicious nodes at start

### DIFF
--- a/Monero/0.17.1.7/linuxamd64.Dockerfile
+++ b/Monero/0.17.1.7/linuxamd64.Dockerfile
@@ -28,8 +28,8 @@ VOLUME /home/monero/.bitmonero
 VOLUME /wallet
 
 # Download and add block.txt to block known-malicious hosts
-ADD https://gui.xmr.pm/files/block.txt /home/monero/.bitmonero/
-RUN chown monero:monero /home/monero/.bitmonero/block.txt
+ADD https://gui.xmr.pm/files/block.txt /home/monero/block.txt
+RUN chown monero:monero /home/monero/block.txt
 
 EXPOSE 18080
 EXPOSE 18081

--- a/Monero/0.17.1.7/linuxamd64.Dockerfile
+++ b/Monero/0.17.1.7/linuxamd64.Dockerfile
@@ -27,6 +27,10 @@ RUN adduser --system --group --disabled-password monero && \
 VOLUME /home/monero/.bitmonero
 VOLUME /wallet
 
+# Download and add block.txt to block known-malicious hosts
+ADD https://gui.xmr.pm/files/block.txt /home/monero/.bitmonero/
+RUN chown monero:monero /home/monero/.bitmonero/block.txt
+
 EXPOSE 18080
 EXPOSE 18081
 EXPOSE 18082


### PR DESCRIPTION
Adding in this text file of IP addresses allows monerod to block known-malicious nodes on start instead of waiting for detection of their malicious behavior.

In order to use this file it also requires https://github.com/btcpayserver/btcpayserver-docker/pull/413, but the container will work properly without that being merged immediately.