### PR TITLE
Bump Electrum Personal Server to v0.2.1.1

### DIFF
--- a/EPS/0.2.1.1/docker-compose.yml
+++ b/EPS/0.2.1.1/docker-compose.yml
@@ -1,0 +1,33 @@
+version: "3"
+
+services:
+  electrum_ps:
+    image: btcpayserver/eps:h
+    restart: unless-stopped
+    ports:
+      - "50002:50002"
+    environment:
+        EPS_CONFIG: |
+            [master-public-keys]
+            wallet = DOCKERXPUB
+            [bitcoin-rpc]
+            host = DOCKERHOST
+            port = DOCKERPORT
+            rpc_user = DOCKERRPC_USER
+            rpc_password = DOCKERRPC_PASSWORD
+            poll_interval_listening = 600
+            poll_interval_connected = 5
+            initial_import_count = 1000
+            gap_limit = 25
+            wallet_filename =
+            [electrum-server]
+            host = 0.0.0.0
+            port = 50002
+            broadcast_method = own-node
+            ip_whitelist = *
+            disable_mempool_fee_histogram = false
+            # certfile = certs/cert.crt
+            # keyfile = certs/cert.key
+            # If you use your own certificates put them in the docker volume, comment out the above and use something like:
+            #certfile = /srv/yourcert.crt
+            #keyfile = /srv/yourkey.key

--- a/EPS/0.2.1.1/docker-entrypoint.sh
+++ b/EPS/0.2.1.1/docker-entrypoint.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -e
+
+cat <<-EOF > "config.ini"
+${EPS_CONFIG}
+EOF
+
+if ! [ -f "/data/cert.crt" ] || ! openssl x509 -checkend 86400 -noout -in /data/cert.crt > /dev/null; then
+    rm -rf /data/cert.*
+    echo "Generating SSL certificates..."
+    openssl genrsa -des3 -passout pass:greenbanana -out /data/cert.pass.key 2048
+    openssl rsa -passin pass:greenbanana -in /data/cert.pass.key -out /data/cert.key
+    rm /data/cert.pass.key
+    openssl req -new -key /data/cert.key -out /data/cert.csr -subj "/CN=SATOSHI NAKAMOTO/O=Electrum/ST=Personal/C=SV"
+    openssl x509 -req -days 1825 -in /data/cert.csr -signkey /data/cert.key -out /data/cert.crt
+fi
+
+# If we don't do this, eps crash
+if ! grep -q "\[watch-only-addresses\]" config.ini; then
+    echo "[watch-only-addresses]" >> config.ini
+    echo "Added dummy [watch-only-addresses] section to config.ini"
+fi
+
+if grep -q "\[electrum-server\]" config.ini; then
+    CERT_CONFIG="certfile = \/data\/cert.crt\nkeyfile = \/data\/cert.key"
+    sed -i "s/\[electrum-server\]/\0\n$CERT_CONFIG/g" config.ini
+    echo "Added certificate settings to the [electrum-server] section of config.ini"
+else
+    echo "[electrum-server]
+certfile = /data/cert.crt
+keyfile = /data/cert.key
+" >> "config.ini"
+    echo "Added [electrum-server] section with certificate settings to config.ini"
+fi
+
+if [ "$1" != "electrum-personal-server" ]; then
+    exec "$@"
+fi
+
+if [[ "${READY_FILE}" ]]; then
+    echo "Waiting $READY_FILE to be created..."
+    while [ ! -f "$READY_FILE" ]; do sleep 1; done
+    echo "The chain is fully synched"
+fi
+
+exec "$@" config.ini

--- a/EPS/0.2.1.1/linuxamd64.Dockerfile
+++ b/EPS/0.2.1.1/linuxamd64.Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.8.1-slim-buster
+
+ENV EPS_VERSION 0.2.1.1
+ENV EPS_SHA256 014ee376144c40a5b5c81405dc5713c5c6803b1a69f0525759a1e630de72269b
+
+RUN apt-get update && \
+    apt-get install -qq --no-install-recommends curl unzip wget tini && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+WORKDIR /tmp
+RUN FILENAME="eps-v${EPS_VERSION}.zip" && \
+    curl -fsSL "https://github.com/chris-belcher/electrum-personal-server/archive/$FILENAME" > "$FILENAME" && \
+    echo "$EPS_SHA256 $FILENAME" | sha256sum -c - && \
+    unzip "$FILENAME" && \
+    DIRECTORY_NAME="electrum-personal-server-eps-v${EPS_VERSION}" && \
+    mv "$DIRECTORY_NAME" "/build/eps" && rm "$FILENAME"
+
+WORKDIR /build/eps
+RUN pip3 install . && mkdir -p /data
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+ENTRYPOINT  [ "tini", "-g", "--", "/docker-entrypoint.sh" ]
+CMD [ "electrum-personal-server" ]

--- a/EPS/0.2.1.1/linuxarm32v7.Dockerfile
+++ b/EPS/0.2.1.1/linuxarm32v7.Dockerfile
@@ -1,0 +1,29 @@
+FROM debian:buster-slim as builder
+RUN apt-get update && apt-get install -qq --no-install-recommends qemu-user-static
+
+FROM arm32v7/python:3.8.1-slim-buster
+
+COPY --from=builder /usr/bin/qemu-arm-static /usr/bin/qemu-arm-static
+
+ENV EPS_VERSION 0.2.1.1
+ENV EPS_SHA256 014ee376144c40a5b5c81405dc5713c5c6803b1a69f0525759a1e630de72269b
+
+RUN apt-get update && \
+    apt-get install -qq --no-install-recommends curl unzip wget tini && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+WORKDIR /tmp
+RUN FILENAME="eps-v${EPS_VERSION}.zip" && \
+    curl -fsSL "https://github.com/chris-belcher/electrum-personal-server/archive/$FILENAME" > "$FILENAME" && \
+    echo "$EPS_SHA256 $FILENAME" | sha256sum -c - && \
+    unzip "$FILENAME" && \
+    DIRECTORY_NAME="electrum-personal-server-eps-v${EPS_VERSION}" && \
+    mv "$DIRECTORY_NAME" "/build/eps" && rm "$FILENAME"
+
+WORKDIR /build/eps
+RUN pip3 install . && mkdir -p /data
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+ENTRYPOINT  [ "tini", "-g", "--", "/docker-entrypoint.sh" ]
+CMD [ "electrum-personal-server" ]

--- a/EPS/0.2.1.1/linuxarm64v8.Dockerfile
+++ b/EPS/0.2.1.1/linuxarm64v8.Dockerfile
@@ -1,0 +1,29 @@
+FROM debian:buster-slim as builder
+RUN apt-get update && apt-get install -qq --no-install-recommends qemu-user-static
+
+FROM arm64v8/python:3.8.1-slim-buster
+
+COPY --from=builder /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
+
+ENV EPS_VERSION 0.2.1.1
+ENV EPS_SHA256 014ee376144c40a5b5c81405dc5713c5c6803b1a69f0525759a1e630de72269b
+
+RUN apt-get update && \
+    apt-get install -qq --no-install-recommends curl unzip wget tini && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+WORKDIR /tmp
+RUN FILENAME="eps-v${EPS_VERSION}.zip" && \
+    curl -fsSL "https://github.com/chris-belcher/electrum-personal-server/archive/$FILENAME" > "$FILENAME" && \
+    echo "$EPS_SHA256 $FILENAME" | sha256sum -c - && \
+    unzip "$FILENAME" && \
+    DIRECTORY_NAME="electrum-personal-server-eps-v${EPS_VERSION}" && \
+    mv "$DIRECTORY_NAME" "/build/eps" && rm "$FILENAME"
+
+WORKDIR /build/eps
+RUN pip3 install . && mkdir -p /data
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+ENTRYPOINT  [ "tini", "-g", "--", "/docker-entrypoint.sh" ]
+CMD [ "electrum-personal-server" ]


### PR DESCRIPTION
This PR should deprecate #13 where files have been moved as opposed to creating new files.
I opened this PR as I didn't want to create any additional work for the original author, but these changes are needed in the long run and an official release for btcpayserver would be very appreciated. If this is not the right approach, please ignore/close this PR.

This commit adds a new subdirectory `0.2.1.1` in `EPS/` containing all dockerfiles for building Electrum Personal Server v0.2.1.1.
