### PR TITLE
Added PrestaShop Dockerfile

### DIFF
--- a/PrestaShop/1.7/Dockerfile
+++ b/PrestaShop/1.7/Dockerfile
@@ -1,0 +1,18 @@
+FROM prestashop/prestashop:1.7
+
+ENV BTCPAY_PLUGIN_VERSION 0.1.0
+
+ENV PS_ROOT '/var/www/html'
+ENV PS_INSTALL_FILE 'src/PrestaShopBundle/Install/Install.php'
+
+# Add the BTCPay module to the modules directory
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends unzip wget \
+    && wget https://github.com/btcpayserver/prestashop-plugin/releases/download/v${BTCPAY_PLUGIN_VERSION}/btcpay.zip -O /tmp/temp.zip \
+    && cd $PS_ROOT/modules && unzip /tmp/temp.zip && rm /tmp/temp.zip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Add the BTCPay module to the preinstalled list after default 'Welcome' module
+RUN sed -i "/'welcome',/a 'btcpay'," "$PS_ROOT/$PS_INSTALL_FILE"
+
+VOLUME ["/var/www/html"]

--- a/PrestaShop/1.7/README.md
+++ b/PrestaShop/1.7/README.md
@@ -1,0 +1,37 @@
+# btcpayserver/prestashop
+
+[![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/btcpayserver/prestashop?style=flat-square)](https://hub.docker.com/repository/docker/btcpayserver/prestashop)
+[![Docker Pulls](https://img.shields.io/docker/pulls/btcpayserver/prestashop?style=flat-square)](https://hub.docker.com/repository/docker/btcpayserver/prestashop)
+[![Docker Image Version (latest semver)](https://img.shields.io/docker/v/btcpayserver/prestashop?sort=semver&style=flat-square)](https://hub.docker.com/repository/docker/btcpayserver/prestashop)
+
+A PrestaShop image with the BTCPay Server plugin pre-installed.
+
+## Getting Started
+
+These instructions will cover usage information and for the docker container 
+
+### Prerequisities
+
+In order to run this container you'll need docker installed.
+
+* [Windows](https://docs.docker.com/windows/started)
+* [OS X](https://docs.docker.com/mac/started/)
+* [Linux](https://docs.docker.com/linux/started/)
+
+### Documentation
+
+This image uses the 1.7 image from [`prestashop/docker`](https://github.com/prestashop/docker). All documentation and further information can be found there.
+
+## Contributing
+
+[![Twitter Follow](https://img.shields.io/twitter/follow/btcpayserver?color=brightgreen&label=Follow%20%40BTCPayServer&style=flat-square)](https://twitter.com/btcpayserver)
+[![BTCPay Server Community](https://img.shields.io/badge/chat-mattermost-brightgreen?style=flat-square)](https://chat.btcpayserver.org/btcpayserver)
+
+BTCPay is built and maintained entirely by volunteer contributors around the internet. We welcome and appreciate new contributions.
+
+Contributors looking to help out, before opening a pull request, please [create an issue](https://github.com/btcpayserver/prestashop-plugin/issues/new/choose) 
+or join [our community chat](https://chat.btcpayserver.org) to get early feedback, discuss best ways to tackle the problem and to ensure there is no work duplication.
+
+## License
+
+BTCPay Server software, logo and designs are provided under [MIT License](LICENSE).


### PR DESCRIPTION
Uses the official prestashop image and contains the [`btcpayserver/prestashop-plugin`](https://github.com/btcpayserver/prestashop-plugin) by default.