### PR TITLE
chore: update to dash 0.17.0.3

### DIFF
--- a/Dash/0.17.0.3/docker-entrypoint.sh
+++ b/Dash/0.17.0.3/docker-entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -e
+
+if [[ "$1" == "dash-cli" || "$1" == "dash-tx" || "$1" == "dashd" || "$1" == "test_dash" ]]; then
+	mkdir -p "$BITCOIN_DATA"
+
+	CONFIG_PREFIX=""
+    if [[ "${BITCOIN_NETWORK}" == "regtest" ]]; then
+        CONFIG_PREFIX=$'regtest=1\n[regtest]'
+    fi
+    if [[ "${BITCOIN_NETWORK}" == "testnet" ]]; then
+        CONFIG_PREFIX=$'testnet=1\n[test]'
+    fi
+    if [[ "${BITCOIN_NETWORK}" == "mainnet" ]]; then
+        CONFIG_PREFIX=$'mainnet=1\n[main]'
+    fi
+
+	cat <<-EOF > "$BITCOIN_DATA/dash.conf"
+	${CONFIG_PREFIX}
+	printtoconsole=1
+	rpcallowip=::/0
+	${BITCOIN_EXTRA_ARGS}
+	EOF
+	chown bitcoin:bitcoin "$BITCOIN_DATA/dash.conf"
+
+	# ensure correct ownership and linking of data directory
+	# we do not update group ownership here, in case users want to mount
+	# a host directory and still retain access to it
+	chown -R bitcoin "$BITCOIN_DATA"
+	ln -sfn "$BITCOIN_DATA" /home/bitcoin/.dashcore
+	chown -h bitcoin:bitcoin /home/bitcoin/.dashcore
+
+	exec gosu bitcoin "$@"
+else
+	exec "$@"
+fi

--- a/Dash/0.17.0.3/linuxamd64.Dockerfile
+++ b/Dash/0.17.0.3/linuxamd64.Dockerfile
@@ -1,0 +1,45 @@
+FROM debian:stretch-slim as builder
+
+RUN set -ex \
+	&& apt-get update \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget
+
+ENV DASH_VERSION 0.17.0
+ENV DASH_URL https://github.com/dashpay/dash/releases/download/v0.17.0.3/dashcore-0.17.0.3-x86_64-linux-gnu.tar.gz
+ENV DASH_SHA256 d4086b1271589e8d72e6ca151a1c8f12e4dc2878d60ec69532d0c48e99391996
+ENV DASH_ASC_URL https://github.com/dashpay/dash/releases/download/v0.17.0.3/SHA256SUMS.asc
+ENV DASH_PGP_KEY 52527BEDABE87984
+
+# install dash binaries
+RUN set -ex \
+	&& cd /tmp \
+	&& wget -qO dash.tar.gz "$DASH_URL" \
+	&& echo "$DASH_SHA256 dash.tar.gz" | sha256sum -c - \
+	&& gpg --keyserver keyserver.ubuntu.com --recv-keys "$DASH_PGP_KEY" \
+	&& wget -qO dash.asc "$DASH_ASC_URL" \
+	&& gpg --verify dash.asc \
+	&& mkdir bin \
+	&& tar -xzvf dash.tar.gz -C /tmp/bin --strip-components=2 "dashcore-$DASH_VERSION/bin/dash-cli" "dashcore-$DASH_VERSION/bin/dashd" \
+	&& cd bin \
+	&& wget -qO gosu "https://github.com/tianon/gosu/releases/download/1.11/gosu-amd64" \
+	&& echo "0b843df6d86e270c5b0f5cbd3c326a04e18f4b7f9b8457fa497b0454c4b138d7 gosu" | sha256sum -c -
+
+FROM debian:stretch-slim
+COPY --from=builder "/tmp/bin" /usr/local/bin
+
+RUN chmod +x /usr/local/bin/gosu && groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
+
+# create data directory
+ENV BITCOIN_DATA /data
+RUN mkdir "$BITCOIN_DATA" \
+	&& chown -R bitcoin:bitcoin "$BITCOIN_DATA" \
+	&& ln -sfn "$BITCOIN_DATA" /home/bitcoin/.dashcore \
+	&& chown -h bitcoin:bitcoin /home/bitcoin/.dashcore
+
+VOLUME /data
+
+COPY docker-entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
+EXPOSE 9998 9999 19998 19999
+CMD ["dashd"]

--- a/Dash/0.17.0.3/linuxarm32v7.Dockerfile
+++ b/Dash/0.17.0.3/linuxarm32v7.Dockerfile
@@ -1,0 +1,49 @@
+# Use manifest image which support all architecture
+FROM debian:stretch-slim as builder
+
+RUN set -ex \
+	&& apt-get update \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget
+
+ENV DASH_VERSION 0.17.0
+ENV DASH_URL https://github.com/dashpay/dash/releases/download/v0.17.0.3/dashcore-0.17.0.3-arm-linux-gnueabihf.tar.gz
+ENV DASH_SHA256 024fa38c48925a684bac217c0915451a3f9d15a1048035ef41ca0c9ffa8c6801
+ENV DASH_ASC_URL https://github.com/dashpay/dash/releases/download/v0.17.0.3/SHA256SUMS.asc
+ENV DASH_PGP_KEY 52527BEDABE87984
+
+# install dash binaries
+RUN set -ex \
+	&& cd /tmp \
+	&& wget -qO dash.tar.gz "$DASH_URL" \
+	&& echo "$DASH_SHA256 dash.tar.gz" | sha256sum -c - \
+	&& gpg --keyserver keyserver.ubuntu.com --recv-keys "$DASH_PGP_KEY" \
+	&& wget -qO dash.asc "$DASH_ASC_URL" \
+	&& gpg --verify dash.asc \
+	&& mkdir bin \
+	&& tar -xzvf dash.tar.gz -C /tmp/bin --strip-components=2 "dashcore-$DASH_VERSION/bin/dash-cli" "dashcore-$DASH_VERSION/bin/dashd" \
+	&& cd bin \
+	&& wget -qO gosu "https://github.com/tianon/gosu/releases/download/1.11/gosu-armhf" \
+	&& echo "171b4a2decc920de0dd4f49278d3e14712da5fa48de57c556f99bcdabe03552e gosu" | sha256sum -c -
+
+# Making sure the builder build an arm image despite being x64
+FROM arm32v7/debian:stretch-slim
+
+COPY --from=builder "/tmp/bin" /usr/local/bin
+#EnableQEMU COPY qemu-arm-static /usr/bin
+
+RUN chmod +x /usr/local/bin/gosu && groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
+
+# create data directory
+ENV BITCOIN_DATA /data
+RUN mkdir "$BITCOIN_DATA" \
+	&& chown -R bitcoin:bitcoin "$BITCOIN_DATA" \
+	&& ln -sfn "$BITCOIN_DATA" /home/bitcoin/.dashcore \
+	&& chown -h bitcoin:bitcoin /home/bitcoin/.dashcore
+
+VOLUME /data
+
+COPY docker-entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
+EXPOSE 9998 9999 19998 19999
+CMD ["dashd"]

--- a/Dash/0.17.0.3/linuxarm64v8.Dockerfile
+++ b/Dash/0.17.0.3/linuxarm64v8.Dockerfile
@@ -1,0 +1,49 @@
+# Use manifest image which support all architecture
+FROM debian:stretch-slim as builder
+
+RUN set -ex \
+	&& apt-get update \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget
+
+ENV DASH_VERSION 0.17.0
+ENV DASH_URL https://github.com/dashpay/dash/releases/download/v0.17.0.3/dashcore-0.17.0.3-aarch64-linux-gnu.tar.gz
+ENV DASH_SHA256 57b7b9a7939a726afc133229dbecc4f46394bf57d32bf3e936403ade2b2a8519
+ENV DASH_ASC_URL https://github.com/dashpay/dash/releases/download/v0.17.0.3/SHA256SUMS.asc
+ENV DASH_PGP_KEY 52527BEDABE87984
+
+# install dash binaries
+RUN set -ex \
+	&& cd /tmp \
+	&& wget -qO dash.tar.gz "$DASH_URL" \
+	&& echo "$DASH_SHA256 dash.tar.gz" | sha256sum -c - \
+	&& gpg --keyserver keyserver.ubuntu.com --recv-keys "$DASH_PGP_KEY" \
+	&& wget -qO dash.asc "$DASH_ASC_URL" \
+	&& gpg --verify dash.asc \
+	&& mkdir bin \
+	&& tar -xzvf dash.tar.gz -C /tmp/bin --strip-components=2 "dashcore-$DASH_VERSION/bin/dash-cli" "dashcore-$DASH_VERSION/bin/dashd" \
+	&& cd bin \
+	&& wget -qO gosu "https://github.com/tianon/gosu/releases/download/1.11/gosu-arm64" \
+	&& echo "5e279972a1c7adee65e3b5661788e8706594b458b7ce318fecbd392492cc4dbd gosu" | sha256sum -c -
+
+# Making sure the builder build an arm image despite being x64
+FROM arm64v8/debian:stretch-slim
+
+COPY --from=builder "/tmp/bin" /usr/local/bin
+#EnableQEMU COPY qemu-aarch64-static /usr/bin
+
+RUN chmod +x /usr/local/bin/gosu && groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
+
+# create data directory
+ENV BITCOIN_DATA /data
+RUN mkdir "$BITCOIN_DATA" \
+	&& chown -R bitcoin:bitcoin "$BITCOIN_DATA" \
+	&& ln -sfn "$BITCOIN_DATA" /home/bitcoin/.dashcore \
+	&& chown -h bitcoin:bitcoin /home/bitcoin/.dashcore
+
+VOLUME /data
+
+COPY docker-entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
+EXPOSE 9998 9999 19998 19999
+CMD ["dashd"]


### PR DESCRIPTION
Dash has updated to `v0.17.0.3` and a hard fork occurred in early August. This PR updates the Dockerfile deps to add this version. I have tested building and running the `x86_64` image locally without any issues.