### PR TITLE
Bump EPS from v0.2.1.1 to v0.2.2

### DIFF
--- a/EPS/0.2.2/docker-compose.yml
+++ b/EPS/0.2.2/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   electrum_ps:
-    image: btcpayserver/eps:0.2.1.1
+    image: btcpayserver/eps:h
     restart: unless-stopped
     ports:
       - "50002:50002"

--- a/EPS/0.2.2/docker-entrypoint.sh
+++ b/EPS/0.2.2/docker-entrypoint.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -e
+
+cat <<-EOF > "config.ini"
+${EPS_CONFIG}
+EOF
+
+if ! [ -f "/data/cert.crt" ] || ! openssl x509 -checkend 86400 -noout -in /data/cert.crt > /dev/null; then
+    rm -rf /data/cert.*
+    echo "Generating SSL certificates..."
+    openssl genrsa -des3 -passout pass:greenbanana -out /data/cert.pass.key 2048
+    openssl rsa -passin pass:greenbanana -in /data/cert.pass.key -out /data/cert.key
+    rm /data/cert.pass.key
+    openssl req -new -key /data/cert.key -out /data/cert.csr -subj "/CN=SATOSHI NAKAMOTO/O=Electrum/ST=Personal/C=SV"
+    openssl x509 -req -days 1825 -in /data/cert.csr -signkey /data/cert.key -out /data/cert.crt
+fi
+
+# If we don't do this, eps crash
+if ! grep -q "\[watch-only-addresses\]" config.ini; then
+    echo "[watch-only-addresses]" >> config.ini
+    echo "Added dummy [watch-only-addresses] section to config.ini"
+fi
+
+if grep -q "\[electrum-server\]" config.ini; then
+    CERT_CONFIG="certfile = \/data\/cert.crt\nkeyfile = \/data\/cert.key"
+    sed -i "s/\[electrum-server\]/\0\n$CERT_CONFIG/g" config.ini
+    echo "Added certificate settings to the [electrum-server] section of config.ini"
+else
+    echo "[electrum-server]
+certfile = /data/cert.crt
+keyfile = /data/cert.key
+" >> "config.ini"
+    echo "Added [electrum-server] section with certificate settings to config.ini"
+fi
+
+if [ "$1" != "electrum-personal-server" ]; then
+    exec "$@"
+fi
+
+if [[ "${READY_FILE}" ]]; then
+    echo "Waiting $READY_FILE to be created..."
+    while [ ! -f "$READY_FILE" ]; do sleep 1; done
+    echo "The chain is fully synched"
+fi
+
+exec "$@" config.ini

--- a/EPS/0.2.2/linuxamd64.Dockerfile
+++ b/EPS/0.2.2/linuxamd64.Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.8.1-slim-buster
+
+ENV EPS_VERSION 0.2.2
+ENV EPS_SHA256 527cc6a8da1f17e2ec4ab4e0e712f002347c307328e794286760c7e34cfb9f2c
+
+RUN apt-get update && \
+    apt-get install -qq --no-install-recommends curl unzip wget tini && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+WORKDIR /tmp
+RUN FILENAME="eps-v${EPS_VERSION}.zip" && \
+    curl -fsSL "https://github.com/chris-belcher/electrum-personal-server/archive/$FILENAME" > "$FILENAME" && \
+    echo "$EPS_SHA256 $FILENAME" | sha256sum -c - && \
+    unzip "$FILENAME" && \
+    DIRECTORY_NAME="electrum-personal-server-eps-v${EPS_VERSION}" && \
+    mv "$DIRECTORY_NAME" "/build/eps" && rm "$FILENAME"
+
+WORKDIR /build/eps
+RUN pip3 install . && mkdir -p /data
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+ENTRYPOINT  [ "tini", "-g", "--", "/docker-entrypoint.sh" ]
+CMD [ "electrum-personal-server" ]

--- a/EPS/0.2.2/linuxarm32v7.Dockerfile
+++ b/EPS/0.2.2/linuxarm32v7.Dockerfile
@@ -1,0 +1,29 @@
+FROM debian:buster-slim as builder
+RUN apt-get update && apt-get install -qq --no-install-recommends qemu-user-static
+
+FROM arm32v7/python:3.8.1-slim-buster
+
+COPY --from=builder /usr/bin/qemu-arm-static /usr/bin/qemu-arm-static
+
+ENV EPS_VERSION 0.2.2
+ENV EPS_SHA256 527cc6a8da1f17e2ec4ab4e0e712f002347c307328e794286760c7e34cfb9f2c
+
+RUN apt-get update && \
+    apt-get install -qq --no-install-recommends curl unzip wget tini && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+WORKDIR /tmp
+RUN FILENAME="eps-v${EPS_VERSION}.zip" && \
+    curl -fsSL "https://github.com/chris-belcher/electrum-personal-server/archive/$FILENAME" > "$FILENAME" && \
+    echo "$EPS_SHA256 $FILENAME" | sha256sum -c - && \
+    unzip "$FILENAME" && \
+    DIRECTORY_NAME="electrum-personal-server-eps-v${EPS_VERSION}" && \
+    mv "$DIRECTORY_NAME" "/build/eps" && rm "$FILENAME"
+
+WORKDIR /build/eps
+RUN pip3 install . && mkdir -p /data
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+ENTRYPOINT  [ "tini", "-g", "--", "/docker-entrypoint.sh" ]
+CMD [ "electrum-personal-server" ]

--- a/EPS/0.2.2/linuxarm64v8.Dockerfile
+++ b/EPS/0.2.2/linuxarm64v8.Dockerfile
@@ -1,0 +1,29 @@
+FROM debian:buster-slim as builder
+RUN apt-get update && apt-get install -qq --no-install-recommends qemu-user-static
+
+FROM arm64v8/python:3.8.1-slim-buster
+
+COPY --from=builder /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
+
+ENV EPS_VERSION 0.2.2
+ENV EPS_SHA256 527cc6a8da1f17e2ec4ab4e0e712f002347c307328e794286760c7e34cfb9f2c
+
+RUN apt-get update && \
+    apt-get install -qq --no-install-recommends curl unzip wget tini && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+WORKDIR /tmp
+RUN FILENAME="eps-v${EPS_VERSION}.zip" && \
+    curl -fsSL "https://github.com/chris-belcher/electrum-personal-server/archive/$FILENAME" > "$FILENAME" && \
+    echo "$EPS_SHA256 $FILENAME" | sha256sum -c - && \
+    unzip "$FILENAME" && \
+    DIRECTORY_NAME="electrum-personal-server-eps-v${EPS_VERSION}" && \
+    mv "$DIRECTORY_NAME" "/build/eps" && rm "$FILENAME"
+
+WORKDIR /build/eps
+RUN pip3 install . && mkdir -p /data
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+ENTRYPOINT  [ "tini", "-g", "--", "/docker-entrypoint.sh" ]
+CMD [ "electrum-personal-server" ]


### PR DESCRIPTION
[v0.2.2](https://github.com/chris-belcher/electrum-personal-server/releases/tag/eps-v0.2.2) is a minor release [without major changes](https://github.com/chris-belcher/electrum-personal-server/blob/master/release-notes).

Verify sha256 checksum:
```
[tbk@home ~]$ curl -fsSL https://github.com/chris-belcher/electrum-personal-server/archive/refs/tags/eps-v0.2.2.zip | sha256sum
> 527cc6a8da1f17e2ec4ab4e0e712f002347c307328e794286760c7e34cfb9f2c
```
