### PR TITLE
Add arm64 support for Monero

### DIFF
--- a/Monero/0.17.2.3/linuxarm64v8.Dockerfile
+++ b/Monero/0.17.2.3/linuxarm64v8.Dockerfile
@@ -2,8 +2,8 @@
 FROM arm64v8/debian:stretch-slim
 
 # Set necessary environment variables
-ENV FILE=monero-linux-armv8-v0.17.3.0.tar.bz2
-ENV FILE_CHECKSUM=8fdb5761f6f4345dc670d184144ce8c2fa56eeb1609ed169e79b202fcca20f7d
+ENV FILE=monero-linux-armv8-v0.17.2.3.tar.bz2
+ENV FILE_CHECKSUM=bbff804dc6fe7d54895ae073f0abfc45ed8819d0585fe00e32080ed2268dc250
 
 # Set SHELL options per https://github.com/hadolint/hadolint/wiki/DL4006
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/Monero/0.17.2.3/linuxarm64v8.Dockerfile
+++ b/Monero/0.17.2.3/linuxarm64v8.Dockerfile
@@ -1,0 +1,53 @@
+# runtime stage
+FROM arm64v8/debian:stretch-slim
+
+# Set necessary environment variables
+ENV FILE=monero-linux-armv8-v0.17.3.0.tar.bz2
+ENV FILE_CHECKSUM=8fdb5761f6f4345dc670d184144ce8c2fa56eeb1609ed169e79b202fcca20f7d
+
+# Set SHELL options per https://github.com/hadolint/hadolint/wiki/DL4006
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Install dependencies
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get -y --no-install-recommends install bzip2 ca-certificates wget curl \
+    && apt-get -y autoremove \
+    && apt-get clean autoclean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Download specified Monero tar.gz and verify downloaded binary against hardcoded checksum
+RUN wget -qO $FILE https://downloads.getmonero.org/cli/$FILE && \
+    echo "$FILE_CHECKSUM $FILE" | sha256sum -c - 
+
+# Extract and set permissions on Monero binaries
+RUN mkdir -p extracted && \
+    tar -jxvf $FILE -C /extracted && \
+    find /extracted/ -type f -print0 | xargs -0 chmod a+x && \
+    find /extracted/ -type f -print0 | xargs -0 mv -t /usr/local/bin/ && \
+    rm -rf extracted && rm $FILE
+
+# Copy notifier script
+COPY ./scripts /scripts/
+RUN find /scripts/ -type f -print0 | xargs -0 chmod a+x
+
+# Create monero user
+RUN adduser --system --group --disabled-password monero && \
+	mkdir -p /wallet /home/monero/.bitmonero && \
+	chown -R monero:monero /home/monero/.bitmonero && \
+	chown -R monero:monero /wallet
+
+# Specify necessary volumes
+VOLUME /home/monero/.bitmonero
+VOLUME /wallet
+
+# Expose p2p, RPC, and ZMQ ports
+EXPOSE 18080
+EXPOSE 18081
+EXPOSE 18082
+
+# Switch to user monero
+USER monero
+
+# Add HEALTHCHECK against get_info endpoint
+HEALTHCHECK --interval=5s --timeout=3s CMD curl --fail http://localhost:18081/get_info || exit 1


### PR DESCRIPTION
This adds arm64 support for Monero. It's currently syncing on my Raspberry Pi 4 (haven't tried setting up a wallet yet, as per the extended setup instructions).

Addresses: https://github.com/btcpayserver/btcpayserver-docker/issues/571