### PR TITLE
Fix environment variable replacement for JoinMarket

### DIFF
--- a/JoinMarket/0.9.3/docker-entrypoint.sh
+++ b/JoinMarket/0.9.3/docker-entrypoint.sh
@@ -30,10 +30,11 @@ while read p; do
   fi
 done <$AUTO_START
 
-# For every env variable JM_FOO=BAR, replace the default configuration value of 'foo' by 'bar'
-while IFS='=' read -r -d '' n v; do
-    n="${n,,}" # lowercase
+# For every env variable JM_FOO=BAR, replace the default configuration value of 'foo' by 'BAR'
+while IFS='=' read -r -d '' envkey parsedval; do
+    n="${envkey,,}" # lowercase
     if [[ "$n" =  jm_* ]]; then
+        v=${!envkey} # reread environment variable - characters might have been dropped (e.g 'ending in =')
         n="${n:3}" # drop jm_
         sed -i "s/^$n = .*/$n = $v/g" "$CONFIG" || echo "Couldn't set : $n = $v, please modify $CONFIG manually"
     fi

--- a/JoinMarket/0.9.3/docker-entrypoint.sh
+++ b/JoinMarket/0.9.3/docker-entrypoint.sh
@@ -36,7 +36,7 @@ while IFS='=' read -r -d '' envkey parsedval; do
     if [[ "$n" =  jm_* ]]; then
         v=${!envkey} # reread environment variable - characters might have been dropped (e.g 'ending in =')
         n="${n:3}" # drop jm_
-        sed -i "s/^$n = .*/$n = $v/g" "$CONFIG" || echo "Couldn't set : $n = $v, please modify $CONFIG manually"
+        sed -i "s/^$n =.*/$n = $v/g" "$CONFIG" || echo "Couldn't set : $n = $v, please modify $CONFIG manually"
     fi
 done < <(env -0)
 #####################################


### PR DESCRIPTION
The current handling of environment variable replacement in JoinMarket has some minor flaws.
- Variables ending in an `=` are truncated
- Empty variables cannot be replaced (e.g `rpc_wallet_file`)
- Disabled configs (via comment) cannot be activated (e.g. `#max_cj_fee_abs = x`)

This change aims to fix the first two of these issues. However, it is a quick fix and there might be better solutions than this.

- Empty variables
Why is this needed? The default value of `rpc_wallet_file` is empty without a whitespace after the delimiter (`=`) causing the regex not to match on this key

- Variable truncation
Some variables might end in the delimiter char (`=`) and are truncated. This is from a real world example trying to replace the `rpc_password` from an Umbrel regtest environment. `JM_RPC_PASSWORD=abcdef_0123456789=` became `abcdef_0123456789` (notice missing `=`)

First version of the fix has been:
```sh
while IFS= read -r -d '' line; do
    key=${line%%=*} # read everything before first '='
    v=${line#*=} # read everything after first '='
    n="${key,,}" # lowercase
```

but I figured it would be best to just reread the env variable again via `${!envkey}`. Is this approach okay?

Regarding default configs disabled via comment: At first I wanted to add a fix, but thought that might better be done separately.