### PR TITLE
fix: The repository does not have a Release file

### DIFF
--- a/Dash/19.0.0/linuxamd64.Dockerfile
+++ b/Dash/19.0.0/linuxamd64.Dockerfile
@@ -1,8 +1,8 @@
-FROM debian:stretch-slim as builder
+FROM debian:bullseye-slim as builder
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg gpg-agent wget
 
 ENV DASH_VERSION 19.0.0
 ENV DASH_URL https://github.com/dashpay/dash/releases/download/v${DASH_VERSION}/dashcore-${DASH_VERSION}-x86_64-linux-gnu.tar.gz
@@ -24,7 +24,7 @@ RUN set -ex \
 	&& wget -qO gosu "https://github.com/tianon/gosu/releases/download/1.11/gosu-amd64" \
 	&& echo "0b843df6d86e270c5b0f5cbd3c326a04e18f4b7f9b8457fa497b0454c4b138d7 gosu" | sha256sum -c -
 
-FROM debian:stretch-slim
+FROM debian:bullseye-slim
 COPY --from=builder "/tmp/bin" /usr/local/bin
 
 RUN chmod +x /usr/local/bin/gosu && groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin

--- a/Dash/19.0.0/linuxarm64v8.Dockerfile
+++ b/Dash/19.0.0/linuxarm64v8.Dockerfile
@@ -1,9 +1,9 @@
 # Use manifest image which support all architecture
-FROM debian:stretch-slim as builder
+FROM debian:bullseye-slim as builder
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg gpg-agent wget
 
 ENV DASH_VERSION 19.0.0
 ENV DASH_URL https://github.com/dashpay/dash/releases/download/v${DASH_VERSION}/dashcore-${DASH_VERSION}-aarch64-linux-gnu.tar.gz
@@ -26,7 +26,7 @@ RUN set -ex \
 	&& echo "5e279972a1c7adee65e3b5661788e8706594b458b7ce318fecbd392492cc4dbd gosu" | sha256sum -c -
 
 # Making sure the builder build an arm image despite being x64
-FROM arm64v8/debian:stretch-slim
+FROM arm64v8/debian:bullseye-slim
 
 COPY --from=builder "/tmp/bin" /usr/local/bin
 #EnableQEMU COPY qemu-aarch64-static /usr/bin


### PR DESCRIPTION
This PR fixes build errors experienced under Debian Stretch in Circle CI since yesterday ([apparently](https://unix.stackexchange.com/a/743863/538761)) by updating the base image to follow upstream Bitcoin use of `debian:bullseye-slim`.