### PR TITLE
Add an explicit user id and group id to bitcoin user

### DIFF
--- a/Bitcoin/24.1/linuxamd64.Dockerfile
+++ b/Bitcoin/24.1/linuxamd64.Dockerfile
@@ -22,10 +22,13 @@ RUN set -ex \
 FROM debian:bullseye-slim
 COPY --from=builder "/tmp/bin" /usr/local/bin
 
+ARG BITCOIN_USER_ID=999
+ARG BITCOIN_GROUP_ID=999
+
 RUN apt-get update && \
     apt-get install -qq --no-install-recommends xxd && \
     rm -rf /var/lib/apt/lists/*
-RUN chmod +x /usr/local/bin/gosu && groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
+RUN chmod +x /usr/local/bin/gosu && groupadd -r -g $BITCOIN_GROUP_ID bitcoin && useradd -r -m -u $BITCOIN_USER_ID -g bitcoin bitcoin
 
 # create data directory
 ENV BITCOIN_DATA /data

--- a/Bitcoin/24.1/linuxarm32v7.Dockerfile
+++ b/Bitcoin/24.1/linuxarm32v7.Dockerfile
@@ -27,10 +27,13 @@ FROM arm32v7/debian:bullseye-slim
 COPY --from=builder "/tmp/bin" /usr/local/bin
 COPY --from=builder /usr/bin/qemu-arm-static /usr/bin/qemu-arm-static
 
+ARG BITCOIN_USER_ID=999
+ARG BITCOIN_GROUP_ID=999
+
 RUN apt-get update && \
     apt-get install -qq --no-install-recommends xxd && \
     rm -rf /var/lib/apt/lists/*
-RUN chmod +x /usr/local/bin/gosu && groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
+RUN chmod +x /usr/local/bin/gosu && groupadd -r -g $BITCOIN_GROUP_ID bitcoin && useradd -r -m -u $BITCOIN_USER_ID -g bitcoin bitcoin
 
 # create data directory
 ENV BITCOIN_DATA /data

--- a/Bitcoin/24.1/linuxarm64v8.Dockerfile
+++ b/Bitcoin/24.1/linuxarm64v8.Dockerfile
@@ -27,10 +27,13 @@ FROM arm64v8/debian:bullseye-slim
 COPY --from=builder "/tmp/bin" /usr/local/bin
 COPY --from=builder /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
 
+ARG BITCOIN_USER_ID=999
+ARG BITCOIN_GROUP_ID=999
+
 RUN apt-get update && \
     apt-get install -qq --no-install-recommends xxd && \
     rm -rf /var/lib/apt/lists/*
-RUN chmod +x /usr/local/bin/gosu && groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
+RUN chmod +x /usr/local/bin/gosu && groupadd -r -g $BITCOIN_GROUP_ID bitcoin && useradd -r -m -u $BITCOIN_USER_ID -g bitcoin bitcoin
 
 # create data directory
 ENV BITCOIN_DATA /data


### PR DESCRIPTION
This PR adds an explicit user id and group id to bitcoin user.

This also adds build args:
`BITCOIN_USER_ID` and `BITCOIN_GROUP_ID `to configure the IDs if needed

`docker build --build-arg BITCOIN_USER_ID=123 --build-arg BITCOIN_GROUP_ID=123 -t bitcoind .`

The IDs must be unused inside the container.

The prior behaviour was non-deterministic i.e. they were the "next" UID/GID. This change retains the value of 999 that was being used for both but explicitly sets it to be certain of predictability in future.

This is a best practise as listed in the Docker docs: https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user

A potential use case for this is having predictable UID/GID on the bitcoin data dir when being sync'd migrated or backed up.

For reference an example of using the build args in a docker-compose file is:

```yaml
version: '3'
services:
  bitcoind:
    build: 
      context: .
      dockerfile: Dockerfile
      args:
        BITCOIN_USER_ID: 123
        BITCOIN_GROUP_ID: 123
```

This change _should_ be totally backwards compatible as the images seem to be assigning 999 to each in the build, but if the base `debian:bullseye-slim` changes or is changed the ids would likely change, this PR sets them explicitly. (it would probably be a good idea to not be 999, but that would not be backwards compatible with existing data in data dirs).

The option `-o` could be added to the `groupadd` and `useradd` commands allow use of a UID or GID that is already in use.

I have only targeted the most recent bitcoind image and I am unsure of etiquette in this repo, I am happy to make changes as needed.

