### PR TITLE
add lnbits 0.12.1

### DIFF
--- a/LNbits/0.12.1/linuxamd64.Dockerfile
+++ b/LNbits/0.12.1/linuxamd64.Dockerfile
@@ -1,0 +1,34 @@
+FROM python:3.10-slim-bullseye
+
+ENV REPO https://github.com/lnbits/lnbits
+ENV REPO_REF 0.12.1
+
+RUN apt-get clean
+RUN apt-get update
+RUN apt-get install -y curl pkg-config build-essential git
+
+RUN curl -sSL https://install.python-poetry.org | python3 -
+ENV PATH="/root/.local/bin:$PATH"
+
+# needed for backups postgresql-client version 14 (pg_dump)
+RUN apt-get install -y apt-utils wget
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+RUN apt-get update
+RUN apt-get install -y postgresql-client-14
+
+WORKDIR /app
+
+RUN git clone "$REPO" . --depth=1 --branch "$REPO_REF" && git checkout "$REPO_REF"
+
+RUN mkdir data
+
+RUN poetry install --only main
+
+# hardcoded so we can ommit the sh in CMD that was used in upstream lnbits Dockerfile
+#ENV LNBITS_PORT="5000"
+#ENV LNBITS_HOST="0.0.0.0"
+
+EXPOSE 5000
+
+CMD ["poetry", "run", "lnbits", "--port", "5000", "--host", "0.0.0.0"]

--- a/LNbits/0.12.1/linuxarm64v8.Dockerfile
+++ b/LNbits/0.12.1/linuxarm64v8.Dockerfile
@@ -1,0 +1,34 @@
+FROM python:3.10-slim-bullseye
+
+ENV REPO https://github.com/lnbits/lnbits
+ENV REPO_REF 0.12.1
+
+RUN apt-get clean
+RUN apt-get update
+RUN apt-get install -y curl pkg-config build-essential git
+
+RUN curl -sSL https://install.python-poetry.org | python3 -
+ENV PATH="/root/.local/bin:$PATH"
+
+# needed for backups postgresql-client version 14 (pg_dump)
+RUN apt-get install -y apt-utils wget
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+RUN apt-get update
+RUN apt-get install -y postgresql-client-14
+
+WORKDIR /app
+
+RUN git clone "$REPO" . --depth=1 --branch "$REPO_REF" && git checkout "$REPO_REF"
+
+RUN mkdir data
+
+RUN poetry install --only main
+
+# hardcoded so we can ommit the sh in CMD that was used in upstream lnbits Dockerfile
+#ENV LNBITS_PORT="5000"
+#ENV LNBITS_HOST="0.0.0.0"
+
+EXPOSE 5000
+
+CMD ["poetry", "run", "lnbits", "--port", "5000", "--host", "0.0.0.0"]


### PR DESCRIPTION
There was a bugfix release for LNBits: https://github.com/lnbits/lnbits/releases/tag/0.12.1

0.12.0 wouldn't start in a docker context with --port and --host directives