### PR TITLE
chore: update to dash 20.1.0

### DIFF
--- a/Dash/20.1.0/docker-entrypoint.sh
+++ b/Dash/20.1.0/docker-entrypoint.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -e
+
+if [[ "$1" == "dash-cli" || "$1" == "dash-tx" || "$1" == "dashd" || "$1" == "test_dash" ]]; then
+	mkdir -p "$BITCOIN_DATA"
+
+	CONFIG_PREFIX=""
+    if [[ "${BITCOIN_NETWORK}" == "regtest" ]]; then
+        CONFIG_PREFIX=$'regtest=1\n[regtest]'
+    fi
+    if [[ "${BITCOIN_NETWORK}" == "testnet" ]]; then
+        CONFIG_PREFIX=$'testnet=1\n[test]'
+    fi
+    if [[ "${BITCOIN_NETWORK}" == "mainnet" ]]; then
+        CONFIG_PREFIX=$'mainnet=1\n[main]'
+    fi
+
+	cat <<-EOF > "$BITCOIN_DATA/dash.conf"
+	${CONFIG_PREFIX}
+	printtoconsole=1
+	rpcallowip=::/0
+	${BITCOIN_EXTRA_ARGS}
+	EOF
+	chown bitcoin:bitcoin "$BITCOIN_DATA/dash.conf"
+	rm -f "$BITCOIN_DATA/settings.json"
+
+	# ensure correct ownership and linking of data directory
+	# we do not update group ownership here, in case users want to mount
+	# a host directory and still retain access to it
+	chown -R bitcoin "$BITCOIN_DATA"
+	ln -sfn "$BITCOIN_DATA" /home/bitcoin/.dashcore
+	chown -h bitcoin:bitcoin /home/bitcoin/.dashcore
+
+	exec gosu bitcoin "$@"
+else
+	exec "$@"
+fi

--- a/Dash/20.1.0/linuxamd64.Dockerfile
+++ b/Dash/20.1.0/linuxamd64.Dockerfile
@@ -1,0 +1,45 @@
+FROM debian:bullseye-slim as builder
+
+RUN set -ex \
+	&& apt-get update \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg gpg-agent wget
+
+ENV DASH_VERSION 20.1.0
+ENV DASH_URL https://github.com/dashpay/dash/releases/download/v${DASH_VERSION}/dashcore-${DASH_VERSION}-x86_64-linux-gnu.tar.gz
+ENV DASH_SHA256 8c5432fa9cb3f3e686ca69d3a3b5166d8cb4188a4d4041546d42a494fb7e015e
+ENV DASH_ASC_URL https://github.com/dashpay/dash/releases/download/v${DASH_VERSION}/SHA256SUMS.asc
+ENV DASH_PGP_KEY 52527BEDABE87984
+
+# install dash binaries
+RUN set -ex \
+	&& cd /tmp \
+	&& wget -qO dash.tar.gz "$DASH_URL" \
+	&& echo "$DASH_SHA256 dash.tar.gz" | sha256sum -c - \
+	&& gpg --keyserver keyserver.ubuntu.com --recv-keys "$DASH_PGP_KEY" \
+	&& wget -qO dash.asc "$DASH_ASC_URL" \
+	&& gpg --verify dash.asc \
+	&& mkdir bin \
+	&& tar -xzvf dash.tar.gz -C /tmp/bin --strip-components=2 "dashcore-$DASH_VERSION/bin/dash-cli" "dashcore-$DASH_VERSION/bin/dashd" \
+	&& cd bin \
+	&& wget -qO gosu "https://github.com/tianon/gosu/releases/download/1.11/gosu-amd64" \
+	&& echo "0b843df6d86e270c5b0f5cbd3c326a04e18f4b7f9b8457fa497b0454c4b138d7 gosu" | sha256sum -c -
+
+FROM debian:bullseye-slim
+COPY --from=builder "/tmp/bin" /usr/local/bin
+
+RUN chmod +x /usr/local/bin/gosu && groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
+
+# create data directory
+ENV BITCOIN_DATA /data
+RUN mkdir "$BITCOIN_DATA" \
+	&& chown -R bitcoin:bitcoin "$BITCOIN_DATA" \
+	&& ln -sfn "$BITCOIN_DATA" /home/bitcoin/.dashcore \
+	&& chown -h bitcoin:bitcoin /home/bitcoin/.dashcore
+
+VOLUME /data
+
+COPY docker-entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
+EXPOSE 9998 9999 19998 19999
+CMD ["dashd"]

--- a/Dash/20.1.0/linuxarm64v8.Dockerfile
+++ b/Dash/20.1.0/linuxarm64v8.Dockerfile
@@ -1,0 +1,49 @@
+# Use manifest image which support all architecture
+FROM debian:bullseye-slim as builder
+
+RUN set -ex \
+	&& apt-get update \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg gpg-agent wget
+
+ENV DASH_VERSION 20.1.0
+ENV DASH_URL https://github.com/dashpay/dash/releases/download/v${DASH_VERSION}/dashcore-${DASH_VERSION}-aarch64-linux-gnu.tar.gz
+ENV DASH_SHA256 0f7b07d2766308cd09ed9f8d746593123fe68dd4b213ec6353dbe7ae5f846d9b
+ENV DASH_ASC_URL https://github.com/dashpay/dash/releases/download/v${DASH_VERSION}/SHA256SUMS.asc
+ENV DASH_PGP_KEY 52527BEDABE87984
+
+# install dash binaries
+RUN set -ex \
+	&& cd /tmp \
+	&& wget -qO dash.tar.gz "$DASH_URL" \
+	&& echo "$DASH_SHA256 dash.tar.gz" | sha256sum -c - \
+	&& gpg --keyserver keyserver.ubuntu.com --recv-keys "$DASH_PGP_KEY" \
+	&& wget -qO dash.asc "$DASH_ASC_URL" \
+	&& gpg --verify dash.asc \
+	&& mkdir bin \
+	&& tar -xzvf dash.tar.gz -C /tmp/bin --strip-components=2 "dashcore-$DASH_VERSION/bin/dash-cli" "dashcore-$DASH_VERSION/bin/dashd" \
+	&& cd bin \
+	&& wget -qO gosu "https://github.com/tianon/gosu/releases/download/1.11/gosu-arm64" \
+	&& echo "5e279972a1c7adee65e3b5661788e8706594b458b7ce318fecbd392492cc4dbd gosu" | sha256sum -c -
+
+# Making sure the builder build an arm image despite being x64
+FROM arm64v8/debian:bullseye-slim
+
+COPY --from=builder "/tmp/bin" /usr/local/bin
+#EnableQEMU COPY qemu-aarch64-static /usr/bin
+
+RUN chmod +x /usr/local/bin/gosu && groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
+
+# create data directory
+ENV BITCOIN_DATA /data
+RUN mkdir "$BITCOIN_DATA" \
+	&& chown -R bitcoin:bitcoin "$BITCOIN_DATA" \
+	&& ln -sfn "$BITCOIN_DATA" /home/bitcoin/.dashcore \
+	&& chown -h bitcoin:bitcoin /home/bitcoin/.dashcore
+
+VOLUME /data
+
+COPY docker-entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
+EXPOSE 9998 9999 19998 19999
+CMD ["dashd"]


### PR DESCRIPTION
Dash has updated to `v20.1.0` recently. This PR updates the Dockerfile deps to add this version. I have tested building and running the `x86_64` image locally without any issues.

The release is here: https://github.com/dashpay/dash/releases/tag/v20.1.0