### PR TITLE
lnbits 0.12.9: readd xxd package needed for dockerentrypoint

### DIFF
--- a/LNbits/0.12.9/linuxamd64.Dockerfile
+++ b/LNbits/0.12.9/linuxamd64.Dockerfile
@@ -34,7 +34,7 @@ ENV REPO_REF 0.12.9
 
 # needed for backups postgresql-client version 14 (pg_dump)
 RUN apt-get update && apt-get -y upgrade && \
-    apt-get -y install gnupg2 curl git lsb-release && \
+    apt-get -y install xxd gnupg2 curl git lsb-release && \
     sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' && \
     curl -s https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
     apt-get update && \

--- a/LNbits/0.12.9/linuxarm64v8.Dockerfile
+++ b/LNbits/0.12.9/linuxarm64v8.Dockerfile
@@ -39,7 +39,7 @@ ENV REPO_REF 0.12.9
 
 # needed for backups postgresql-client version 14 (pg_dump)
 RUN apt-get update && apt-get -y upgrade && \
-    apt-get -y install gnupg2 curl git lsb-release && \
+    apt-get -y install xxd gnupg2 curl git lsb-release && \
     sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' && \
     curl -s https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
     apt-get update && \


### PR DESCRIPTION
and thats why you test locally before deploying.

sorry for the hassle.