### PR TITLE
Version bump on Cloudflared

### DIFF
--- a/Cloudflared/2024.8.2/linuxamd64.Dockerfile
+++ b/Cloudflared/2024.8.2/linuxamd64.Dockerfile
@@ -1,0 +1,26 @@
+FROM golang:1.23.0 as builder
+ENV GO111MODULE=on \
+    CGO_ENABLED=0 \ 
+    CLOUDFLARED_VERSION=2024.8.2
+WORKDIR /go/src/github.com/cloudflare/cloudflared/
+
+# copy our sources into the builder image
+RUN git clone --branch ${CLOUDFLARED_VERSION} --single-branch --depth 1 https://github.com/cloudflare/cloudflared.git .
+
+# compile cloudflared
+RUN GOOS=linux GOARCH=amd64 make cloudflared
+
+# use a distroless base image with glibc
+FROM --platform=amd64 gcr.io/distroless/base-debian11:nonroot
+
+LABEL org.opencontainers.image.source="https://github.com/cloudflare/cloudflared"
+
+# copy our compiled binary
+COPY --from=builder --chown=nonroot /go/src/github.com/cloudflare/cloudflared/cloudflared /usr/local/bin/
+
+# run as non-privileged user
+USER nonroot
+
+# command / entrypoint of container
+ENTRYPOINT ["cloudflared", "--no-autoupdate"]
+CMD ["version"]

--- a/Cloudflared/2024.8.2/linuxarm32v7.Dockerfile
+++ b/Cloudflared/2024.8.2/linuxarm32v7.Dockerfile
@@ -1,0 +1,26 @@
+FROM golang:1.23.0 as builder
+ENV GO111MODULE=on \
+    CGO_ENABLED=0 \ 
+    CLOUDFLARED_VERSION=2024.8.2
+WORKDIR /go/src/github.com/cloudflare/cloudflared/
+
+# copy our sources into the builder image
+RUN git clone --branch ${CLOUDFLARED_VERSION} --single-branch --depth 1 https://github.com/cloudflare/cloudflared.git .
+
+# compile cloudflared
+RUN GOOS=linux GOARCH=arm make cloudflared
+
+# use a distroless base image with glibc
+FROM --platform=arm gcr.io/distroless/base-debian11:nonroot
+
+LABEL org.opencontainers.image.source="https://github.com/cloudflare/cloudflared"
+
+# copy our compiled binary
+COPY --from=builder --chown=nonroot /go/src/github.com/cloudflare/cloudflared/cloudflared /usr/local/bin/
+
+# run as non-privileged user
+USER nonroot
+
+# command / entrypoint of container
+ENTRYPOINT ["cloudflared", "--no-autoupdate"]
+CMD ["version"]

--- a/Cloudflared/2024.8.2/linuxarm64v8.Dockerfile
+++ b/Cloudflared/2024.8.2/linuxarm64v8.Dockerfile
@@ -1,0 +1,26 @@
+FROM golang:1.23.0 as builder
+ENV GO111MODULE=on \
+    CGO_ENABLED=0 \ 
+    CLOUDFLARED_VERSION=2024.8.2
+WORKDIR /go/src/github.com/cloudflare/cloudflared/
+
+# copy our sources into the builder image
+RUN git clone --branch ${CLOUDFLARED_VERSION} --single-branch --depth 1 https://github.com/cloudflare/cloudflared.git .
+
+# compile cloudflared
+RUN GOOS=linux GOARCH=arm64 make cloudflared
+
+# use a distroless base image with glibc
+FROM --platform=arm64 gcr.io/distroless/base-debian11:nonroot
+
+LABEL org.opencontainers.image.source="https://github.com/cloudflare/cloudflared"
+
+# copy our compiled binary
+COPY --from=builder --chown=nonroot /go/src/github.com/cloudflare/cloudflared/cloudflared /usr/local/bin/
+
+# run as non-privileged user
+USER nonroot
+
+# command / entrypoint of container
+ENTRYPOINT ["cloudflared", "--no-autoupdate"]
+CMD ["version"]


### PR DESCRIPTION
Bump to recommend version, will be required for PR to [btcpayserver-docker](https://github.com/btcpayserver/btcpayserver-docker) repo to consume new image.