### PR TITLE
Dogecoin v1.14.9 and added  ARM64 support

### DIFF
--- a/Dogecoin/1.14.9/docker-entrypoint.sh
+++ b/Dogecoin/1.14.9/docker-entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -e
+
+if [[ "$1" == "dogecoin-cli" || "$1" == "dogecoin-tx" || "$1" == "dogecoind" || "$1" == "test_dogecoin" ]]; then
+	mkdir -p "$DOGECOIN_DATA"
+
+	CONFIG_PREFIX=""
+    if [[ "${BITCOIN_NETWORK}" == "regtest" ]]; then
+        CONFIG_PREFIX=$'regtest=1\n'
+    fi
+    if [[ "${BITCOIN_NETWORK}" == "testnet" ]]; then
+        CONFIG_PREFIX=$'testnet=1\n'
+    fi
+    if [[ "${BITCOIN_NETWORK}" == "mainnet" ]]; then
+        CONFIG_PREFIX=$'mainnet=1\n'
+    fi
+
+	cat <<-EOF > "$DOGECOIN_DATA/dogecoin.conf"
+	${CONFIG_PREFIX}
+	printtoconsole=1
+	rpcallowip=::/0
+	${DOGECOIN_EXTRA_ARGS}
+	EOF
+	chown dogecoin:dogecoin "$DOGECOIN_DATA/dogecoin.conf"
+
+	# ensure correct ownership and linking of data directory
+	# we do not update group ownership here, in case users want to mount
+	# a host directory and still retain access to it
+	chown -R dogecoin "$DOGECOIN_DATA"
+	ln -sfn "$DOGECOIN_DATA" /home/dogecoin/.dogecoin
+	chown -h dogecoin:dogecoin /home/dogecoin/.dogecoin
+
+	exec gosu dogecoin "$@"
+else
+	exec "$@"
+fi

--- a/Dogecoin/1.14.9/linuxamd64.Dockerfile
+++ b/Dogecoin/1.14.9/linuxamd64.Dockerfile
@@ -1,0 +1,34 @@
+FROM debian:bookworm-slim
+
+RUN groupadd -r dogecoin && useradd -r -m -g dogecoin dogecoin
+
+RUN set -ex \
+	&& apt-get update \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
+	&& rm -rf /var/lib/apt/lists/*
+
+ENV DOGECOIN_VERSION 1.14.9
+ENV DOGECOIN_URL https://github.com/dogecoin/dogecoin/releases/download/v1.14.9/dogecoin-1.14.9-x86_64-linux-gnu.tar.gz
+ENV DOGECOIN_SHA256 4f227117b411a7c98622c970986e27bcfc3f547a72bef65e7d9e82989175d4f8
+
+# install Dogecoin binaries
+RUN set -ex \
+	&& cd /tmp \
+	&& wget -qO dogecoin.tar.gz "$DOGECOIN_URL" \
+	&& echo "$DOGECOIN_SHA256 dogecoin.tar.gz" | sha256sum -c - \
+	&& tar -xzvf dogecoin.tar.gz -C /usr/local --strip-components=1 --exclude=*-qt \
+	&& rm -rf /tmp/*
+
+# create data directory
+ENV DOGECOIN_DATA /data
+RUN mkdir "$DOGECOIN_DATA" \
+	&& chown -R dogecoin:dogecoin "$DOGECOIN_DATA" \
+	&& ln -sfn "$DOGECOIN_DATA" /home/dogecoin/.dogecoin \
+	&& chown -h dogecoin:dogecoin /home/dogecoin/.dogecoin
+VOLUME /data
+
+COPY docker-entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
+EXPOSE 5222 5223 25222 25223 25222 25223
+CMD ["dogecoind"] 

--- a/Dogecoin/1.14.9/linuxarm64v8.Dockerfile
+++ b/Dogecoin/1.14.9/linuxarm64v8.Dockerfile
@@ -1,0 +1,35 @@
+# Use manifest image which support all architecture
+FROM arm64v8/debian:bookworm-slim
+
+RUN groupadd -r dogecoin && useradd -r -m -g dogecoin dogecoin
+
+RUN set -ex \
+	&& apt-get update \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
+	&& rm -rf /var/lib/apt/lists/*
+
+ENV DOGECOIN_VERSION 1.14.9
+ENV DOGECOIN_URL https://github.com/dogecoin/dogecoin/releases/download/v1.14.9/dogecoin-1.14.9-aarch64-linux-gnu.tar.gz
+ENV DOGECOIN_SHA256 6928c895a20d0bcb6d5c7dcec753d35c884a471aaf8ad4242a89a96acb4f2985
+
+# install Dogecoin binaries
+RUN set -ex \
+	&& cd /tmp \
+	&& wget -qO dogecoin.tar.gz "$DOGECOIN_URL" \
+	&& echo "$DOGECOIN_SHA256 dogecoin.tar.gz" | sha256sum -c - \
+	&& tar -xzvf dogecoin.tar.gz -C /usr/local --strip-components=1 --exclude=*-qt \
+	&& rm -rf /tmp/*
+
+# create data directory
+ENV DOGECOIN_DATA /data
+RUN mkdir "$DOGECOIN_DATA" \
+	&& chown -R dogecoin:dogecoin "$DOGECOIN_DATA" \
+	&& ln -sfn "$DOGECOIN_DATA" /home/dogecoin/.dogecoin \
+	&& chown -h dogecoin:dogecoin /home/dogecoin/.dogecoin
+VOLUME /data
+
+COPY docker-entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
+EXPOSE 5222 5223 25222 25223 25222 25223
+CMD ["dogecoind"] 


### PR DESCRIPTION
# Dogecoin v1.14.9 and added ARM64 support
Updated Dogecoin implementation for BTCPay Server from v1.14.7 to v1.14.9 with added ARM64/v8 support.

- Upgraded Dogecoin Core to v1.14.9
- Added ARM64/v8 architecture support
- Maintained AMD64 compatibility
- Tested integration with BTCPay Server
- Successfully built and tested on ARM64/v8 architecture
- Confirmed blockchain synchronization and pruning functionality