### PR TITLE
Add MutinyNet 2fda7bfc027e (Template Hash)

### DIFF
--- a/MutinyNet/2fda7bfc027e/docker-entrypoint.sh
+++ b/MutinyNet/2fda7bfc027e/docker-entrypoint.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+set -e
+
+if [[ "$1" == "bitcoin-cli" || "$1" == "bitcoin-tx" || "$1" == "bitcoind" || "$1" == "test_bitcoin" ]]; then
+	mkdir -p "$BITCOIN_DATA"
+
+	CONFIG_PREFIX=""
+	if [[ "${BITCOIN_NETWORK}" == "regtest" ]]; then
+		CONFIG_PREFIX=$'regtest=1\n[regtest]'
+	elif [[ "${BITCOIN_NETWORK}" == "testnet" ]]; then
+		CONFIG_PREFIX=$'testnet=1\n[test]'
+	elif [[ "${BITCOIN_NETWORK}" == "mainnet" ]]; then
+		CONFIG_PREFIX=$'mainnet=1\n[main]'
+	elif [[ "${BITCOIN_NETWORK}" == "signet" ]]; then
+		CONFIG_PREFIX=$'signet=1\n[signet]'
+	else 
+		BITCOIN_NETWORK="mainnet"
+		CONFIG_PREFIX=$'mainnet=1\n[main]'
+	fi
+
+	if [[ "$BITCOIN_WALLETDIR" ]] && [[ "$BITCOIN_NETWORK" ]]; then
+		NL=$'\n'
+		WALLETDIR="$BITCOIN_WALLETDIR/${BITCOIN_NETWORK}"
+		WALLETFILE="${WALLETDIR}/wallet.dat"
+		mkdir -p "$WALLETDIR"
+		chown -R bitcoin:bitcoin "$WALLETDIR"
+		CONFIG_PREFIX="${CONFIG_PREFIX}${NL}walletdir=${WALLETDIR}${NL}"
+		: "${CREATE_WALLET:=true}"
+		if ! [[ -f "${WALLETFILE}" ]] && [[ "${CREATE_WALLET}" != "false" ]]; then
+		  echo "The wallet does not exists, creating it at ${WALLETDIR}..."
+		  gosu bitcoin bitcoin-wallet "-datadir=${WALLETDIR}" "-legacy" "-wallet=" create
+		fi
+	fi
+
+	cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
+	${CONFIG_PREFIX}
+	printtoconsole=1
+	rpcallowip=::/0
+	${BITCOIN_EXTRA_ARGS}
+	EOF
+	chown bitcoin:bitcoin "$BITCOIN_DATA/bitcoin.conf"
+
+	if [[ "${BITCOIN_TORCONTROL}" ]]; then
+		# Because bitcoind only accept torcontrol= host as an ip only, we resolve it here and add to config
+		TOR_CONTROL_HOST=$(echo ${BITCOIN_TORCONTROL} | cut -d ':' -f 1)
+		TOR_CONTROL_PORT=$(echo ${BITCOIN_TORCONTROL} | cut -d ':' -f 2)
+		if [[ "$TOR_CONTROL_HOST" ]] && [[ "$TOR_CONTROL_PORT" ]]; then
+			TOR_IP=$(getent hosts $TOR_CONTROL_HOST | cut -d ' ' -f 1)
+			echo "torcontrol=$TOR_IP:$TOR_CONTROL_PORT" >> "$BITCOIN_DATA/bitcoin.conf"
+			echo "Added "torcontrol=$TOR_IP:$TOR_CONTROL_PORT" to $BITCOIN_DATA/bitcoin.conf"
+		else
+			echo "Invalid BITCOIN_TORCONTROL"
+		fi
+	fi
+
+	# ensure correct ownership and linking of data directory
+	# we do not update group ownership here, in case users want to mount
+	# a host directory and still retain access to it
+	chown -R bitcoin "$BITCOIN_DATA"
+	ln -sfn "$BITCOIN_DATA" /home/bitcoin/.bitcoin
+	chown -h bitcoin:bitcoin /home/bitcoin/.bitcoin
+	rm -f /home/bitcoin/.bitcoin/settings.json
+
+	# peers_dat is routinely corrupted, preventing bitcoind to start, see https://github.com/bitcoin/bitcoin/issues/26599
+	# This should be fixed in 24.1, but doesn't hurt to keep it
+	peers_dat="/home/bitcoin/.bitcoin/peers.dat"
+	peers_dat_corrupted="/home/bitcoin/.bitcoin/peers_corrupted.dat"
+	if [[ -f "${peers_dat}" ]]; then
+		actual_hash=$(head -c -32 "${peers_dat}" | sha256sum | cut -c1-64 | xxd -r -p | sha256sum | cut -c1-64)
+		expected_hash=$(tail -c 32 "${peers_dat}" | xxd -ps -c 32)
+		if [[ "${actual_hash}" != "${expected_hash}" ]]; then
+			echo "${peers_dat} is corrupted, moving it to ${peers_dat_corrupted}"
+			rm -f "${peers_dat_corrupted}"
+			mv "${peers_dat}" "${peers_dat_corrupted}"
+		fi
+	fi
+
+	exec gosu bitcoin "$@"
+else
+	exec "$@"
+fi

--- a/MutinyNet/2fda7bfc027e/linuxamd64.Dockerfile
+++ b/MutinyNet/2fda7bfc027e/linuxamd64.Dockerfile
@@ -1,0 +1,45 @@
+FROM debian:bookworm-slim as builder
+
+RUN set -ex \
+	&& apt-get update \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu wget
+
+ENV BITCOIN_VERSION 2fda7bfc027e
+ENV BITCOIN_URL https://github.com/benthecarman/bitcoin/releases/download/mutinynet-inq-template-hash/bitcoin-2fda7bfc027e-x86_64-linux-gnu.tar.gz
+
+
+# install bitcoin binaries
+RUN set -ex \
+	&& cd /tmp \
+	&& wget -qO bitcoin.tar.gz "$BITCOIN_URL" \
+	&& mkdir bin \
+	&& tar -xzvf bitcoin.tar.gz -C /tmp/bin --strip-components=2 "bitcoin-$BITCOIN_VERSION/bin/bitcoin-cli" "bitcoin-$BITCOIN_VERSION/bin/bitcoind" "bitcoin-$BITCOIN_VERSION/bin/bitcoin-wallet" \
+	&& cd bin \
+	&& wget -qO gosu "https://github.com/tianon/gosu/releases/download/1.16/gosu-amd64" \
+	&& echo "3a4e1fc7430f9e7dd7b0cbbe0bfde26bf4a250702e84cf48a1eb2b631c64cf13 gosu" | sha256sum -c -
+
+FROM debian:bookworm-slim
+COPY --from=builder "/tmp/bin" /usr/local/bin
+
+ARG BITCOIN_USER_ID=999
+ARG BITCOIN_GROUP_ID=999
+
+RUN apt-get update && \
+    apt-get install -qq --no-install-recommends xxd && \
+    rm -rf /var/lib/apt/lists/*
+RUN chmod +x /usr/local/bin/gosu && groupadd -r -g $BITCOIN_GROUP_ID bitcoin && useradd -r -m -u $BITCOIN_USER_ID -g bitcoin bitcoin
+
+# create data directory
+ENV BITCOIN_DATA /data
+RUN mkdir "$BITCOIN_DATA" \
+	&& chown -R bitcoin:bitcoin "$BITCOIN_DATA" \
+	&& ln -sfn "$BITCOIN_DATA" /home/bitcoin/.bitcoin \
+	&& chown -h bitcoin:bitcoin /home/bitcoin/.bitcoin
+
+VOLUME /data
+
+COPY docker-entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
+EXPOSE 8332 8333 18332 18333 18443 18444
+CMD ["bitcoind"]

--- a/MutinyNet/2fda7bfc027e/linuxarm32v7.Dockerfile
+++ b/MutinyNet/2fda7bfc027e/linuxarm32v7.Dockerfile
@@ -1,0 +1,49 @@
+# Use manifest image which support all architecture
+FROM debian:bookworm-slim as builder
+
+RUN set -ex \
+	&& apt-get update \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu wget
+RUN apt-get install -qq --no-install-recommends qemu-user-static binfmt-support
+
+ENV BITCOIN_VERSION 2fda7bfc027e
+ENV BITCOIN_URL https://github.com/benthecarman/bitcoin/releases/download/mutinynet-inq-template-hash/bitcoin-2fda7bfc027e-arm-linux-gnueabihf.tar.gz
+
+# install bitcoin binaries
+RUN set -ex \
+	&& cd /tmp \
+	&& wget -qO bitcoin.tar.gz "$BITCOIN_URL" \
+	&& mkdir bin \
+	&& tar -xzvf bitcoin.tar.gz -C /tmp/bin --strip-components=2 "bitcoin-$BITCOIN_VERSION/bin/bitcoin-cli" "bitcoin-$BITCOIN_VERSION/bin/bitcoind" "bitcoin-$BITCOIN_VERSION/bin/bitcoin-wallet" \
+	&& cd bin \
+	&& wget -qO gosu "https://github.com/tianon/gosu/releases/download/1.16/gosu-armhf" \
+	&& echo "1b670d5426e1ddbb14a14280afb6850a48c219189d4cfe7e6eb2cc08a4fc7785 gosu" | sha256sum -c -
+
+# Making sure the builder build an arm image despite being x64
+FROM arm32v7/debian:bookworm-slim
+
+COPY --from=builder "/tmp/bin" /usr/local/bin
+COPY --from=builder /usr/bin/qemu-arm-static /usr/bin/qemu-arm-static
+
+ARG BITCOIN_USER_ID=999
+ARG BITCOIN_GROUP_ID=999
+
+RUN apt-get update && \
+    apt-get install -qq --no-install-recommends xxd && \
+    rm -rf /var/lib/apt/lists/*
+RUN chmod +x /usr/local/bin/gosu && groupadd -r -g $BITCOIN_GROUP_ID bitcoin && useradd -r -m -u $BITCOIN_USER_ID -g bitcoin bitcoin
+
+# create data directory
+ENV BITCOIN_DATA /data
+RUN mkdir "$BITCOIN_DATA" \
+	&& chown -R bitcoin:bitcoin "$BITCOIN_DATA" \
+	&& ln -sfn "$BITCOIN_DATA" /home/bitcoin/.bitcoin \
+	&& chown -h bitcoin:bitcoin /home/bitcoin/.bitcoin
+
+VOLUME /data
+
+COPY docker-entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
+EXPOSE 8332 8333 18332 18333 18443 18444
+CMD ["bitcoind"]

--- a/MutinyNet/2fda7bfc027e/linuxarm64v8.Dockerfile
+++ b/MutinyNet/2fda7bfc027e/linuxarm64v8.Dockerfile
@@ -1,0 +1,49 @@
+# Use manifest image which support all architecture
+FROM debian:bookworm-slim as builder
+
+RUN set -ex \
+	&& apt-get update \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu wget
+RUN apt-get install -qq --no-install-recommends qemu-user-static binfmt-support
+
+ENV BITCOIN_VERSION 2fda7bfc027e
+ENV BITCOIN_URL https://github.com/benthecarman/bitcoin/releases/download/mutinynet-inq-template-hash/bitcoin-2fda7bfc027e-aarch64-linux-gnu.tar.gz
+
+# install bitcoin binaries
+RUN set -ex \
+	&& cd /tmp \
+	&& wget -qO bitcoin.tar.gz "$BITCOIN_URL" \
+	&& mkdir bin \
+	&& tar -xzvf bitcoin.tar.gz -C /tmp/bin --strip-components=2 "bitcoin-$BITCOIN_VERSION/bin/bitcoin-cli" "bitcoin-$BITCOIN_VERSION/bin/bitcoind" "bitcoin-$BITCOIN_VERSION/bin/bitcoin-wallet" \
+	&& cd bin \
+	&& wget -qO gosu "https://github.com/tianon/gosu/releases/download/1.16/gosu-arm64" \
+	&& echo "23fa49907d5246d2e257de3bf883f57fba47fe1f559f7e732ff16c0f23d2b6a6 gosu" | sha256sum -c -
+
+# Making sure the builder build an arm image despite being x64
+FROM arm64v8/debian:bookworm-slim
+
+COPY --from=builder "/tmp/bin" /usr/local/bin
+COPY --from=builder /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
+
+ARG BITCOIN_USER_ID=999
+ARG BITCOIN_GROUP_ID=999
+
+RUN apt-get update && \
+    apt-get install -qq --no-install-recommends xxd && \
+    rm -rf /var/lib/apt/lists/*
+RUN chmod +x /usr/local/bin/gosu && groupadd -r -g $BITCOIN_GROUP_ID bitcoin && useradd -r -m -u $BITCOIN_USER_ID -g bitcoin bitcoin
+
+# create data directory
+ENV BITCOIN_DATA /data
+RUN mkdir "$BITCOIN_DATA" \
+	&& chown -R bitcoin:bitcoin "$BITCOIN_DATA" \
+	&& ln -sfn "$BITCOIN_DATA" /home/bitcoin/.bitcoin \
+	&& chown -h bitcoin:bitcoin /home/bitcoin/.bitcoin
+
+VOLUME /data
+
+COPY docker-entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
+EXPOSE 8332 8333 18332 18333 18443 18444
+CMD ["bitcoind"]


### PR DESCRIPTION
Adds a new MutinyNet variant built from the latest [benthecarman/bitcoin](https://github.com/benthecarman/bitcoin/releases) release — **Mutinynet v29.0 + Template Hash** ([`mutinynet-inq-template-hash`](https://github.com/benthecarman/bitcoin/releases/tag/mutinynet-inq-template-hash), commit `2fda7bfc027e`, published 2026-05-17).

Follows the existing MutinyNet pattern: the three Dockerfiles and `docker-entrypoint.sh` are identical to the previous variant (`d4a86277ed8a`) except for `BITCOIN_VERSION` and `BITCOIN_URL`.

Pushing the `MutinyNet/2fda7bfc027e` tag will publish `btcpayserver/mutinynet:2fda7bfc027e` for amd64, arm64v8 and arm32v7.

Release assets used:
- amd64: `bitcoin-2fda7bfc027e-x86_64-linux-gnu.tar.gz`
- arm64v8: `bitcoin-2fda7bfc027e-aarch64-linux-gnu.tar.gz`
- arm32v7: `bitcoin-2fda7bfc027e-arm-linux-gnueabihf.tar.gz`
