### PR TITLE
Bump Bitcoin Core to 31.1

### DIFF
--- a/Bitcoin/31.1/docker-entrypoint.sh
+++ b/Bitcoin/31.1/docker-entrypoint.sh
@@ -129,7 +129,7 @@ if [[ "$1" == "bitcoin-cli" || "$1" == "bitcoin-tx" || "$1" == "bitcoind" || "$1
 	chown -h bitcoin:bitcoin /home/bitcoin/.bitcoin
 	rm -f /home/bitcoin/.bitcoin/settings.json
 
-	if [[ "${need_migrate}" == "true" ]]; then
+	if [[ "${need_migrate}" == "true" && "$1" == "bitcoind" ]]; then
 		echo "Migrating legacy bitcoin wallet..."
 		gosu bitcoin "$@" &
 		BITCOIN_PID=$!

--- a/Bitcoin/31.1/docker-entrypoint.sh
+++ b/Bitcoin/31.1/docker-entrypoint.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+set -e
+
+is_sqlite()
+{
+	local f=$1
+	# read first 16 bytes and compare to the SQLite header
+	printf 'SQLite format 3\0' | cmp -n 16 -s - "$f"
+}
+
+if [[ "$1" == "bitcoin-cli" || "$1" == "bitcoin-tx" || "$1" == "bitcoind" || "$1" == "test_bitcoin" ]]; then
+	mkdir -p "$BITCOIN_DATA"
+
+	CONFIG_PREFIX=""
+	if [[ "${BITCOIN_NETWORK}" == "regtest" ]]; then
+		CONFIG_PREFIX=$'regtest=1\n[regtest]'
+	elif [[ "${BITCOIN_NETWORK}" == "testnet" ]]; then
+		CONFIG_PREFIX=$'testnet=1\n[test]'
+	elif [[ "${BITCOIN_NETWORK}" == "mainnet" ]]; then
+		CONFIG_PREFIX=$'[main]'
+	elif [[ "${BITCOIN_NETWORK}" == "signet" ]]; then
+		CONFIG_PREFIX=$'signet=1\n[signet]'
+	else
+		BITCOIN_NETWORK="mainnet"
+		CONFIG_PREFIX=$'[main]'
+	fi
+
+	need_migrate=false
+	if [[ "$BITCOIN_WALLETDIR" ]] && [[ "$BITCOIN_NETWORK" ]]; then
+		NL=$'\n'
+		WALLET_NAME="default"
+		NETWORK_WALLETDIR="${BITCOIN_WALLETDIR}/${BITCOIN_NETWORK}"
+		WALLETDIR="${NETWORK_WALLETDIR}/${WALLET_NAME}"
+		WALLETFILE="${WALLETDIR}/wallet.dat"
+		LEGACY_WALLETDIR="${NETWORK_WALLETDIR}"
+		LEGACY_WALLETFILE="${LEGACY_WALLETDIR}/wallet.dat"
+		mkdir -p "${NETWORK_WALLETDIR}"
+		chown -R bitcoin:bitcoin "${NETWORK_WALLETDIR}"
+		CONFIG_PREFIX="${CONFIG_PREFIX}${NL}walletdir=${NETWORK_WALLETDIR}${NL}"
+		: "${CREATE_WALLET:=true}"
+
+		if [[ "${CREATE_WALLET}" != "false" ]]; then
+			CONFIG_PREFIX="${CONFIG_PREFIX}${NL}wallet=${WALLET_NAME}${NL}"
+			if [[ -f "${LEGACY_WALLETFILE}" ]] && ! [[ -f "${WALLETFILE}" ]]; then
+				mkdir -p "${WALLETDIR}"
+				chown -R bitcoin:bitcoin "${WALLETDIR}"
+				mv "${LEGACY_WALLETFILE}" "${WALLETFILE}"
+				[[ -f "${LEGACY_WALLETDIR}/db.log" ]] && mv "${LEGACY_WALLETDIR}/db.log" "${WALLETDIR}/db.log"
+				[[ -f "${LEGACY_WALLETDIR}/database" ]] && mv "${LEGACY_WALLETDIR}/database" "${WALLETDIR}/database"
+				echo "Moved ${LEGACY_WALLETFILE} -> ${WALLETFILE}"
+			fi
+			if ! [[ -f "${WALLETFILE}" ]]; then
+				echo "The wallet does not exists, creating it at ${NETWORK_WALLETDIR}..."
+				case "${BITCOIN_NETWORK}" in
+				mainnet)
+					NETWORK_FLAG=""
+					;;
+				testnet)
+					NETWORK_FLAG="-testnet"
+					;;
+				signet)
+					NETWORK_FLAG="-signet"
+					;;
+				regtest)
+					NETWORK_FLAG="-regtest"
+					;;
+				*)
+					echo "Unknown BITCOIN_NETWORK: ${BITCOIN_NETWORK}" >&2
+					exit 1
+					;;
+				esac
+				gosu bitcoin bitcoin-wallet ${NETWORK_FLAG} "-datadir=${NETWORK_WALLETDIR}" "-wallet=${WALLET_NAME}" create
+
+				# This stupid utility is creating the file somewhere depending on the network flag...
+				case "${BITCOIN_NETWORK}" in
+				mainnet)
+					;;
+				testnet)
+					mv "${NETWORK_WALLETDIR}/testnet3/default" "${NETWORK_WALLETDIR}/default"
+					rm -rf "${NETWORK_WALLETDIR}/testnet3"
+					;;
+				signet)
+					mv "${NETWORK_WALLETDIR}/signet/default" "${NETWORK_WALLETDIR}/default"
+					rm -rf "${NETWORK_WALLETDIR}/signet"
+					;;
+				regtest)
+					mv "${NETWORK_WALLETDIR}/regtest/default" "${NETWORK_WALLETDIR}/default"
+					rm -rf "${NETWORK_WALLETDIR}/regtest"
+					;;
+				*)
+					echo "Unknown BITCOIN_NETWORK: ${BITCOIN_NETWORK}" >&2
+					exit 1
+					;;
+				esac
+
+			elif ! is_sqlite "${WALLETFILE}"; then
+				need_migrate=true
+				echo "Legacy wallet migration needed"
+			fi
+		fi
+	fi
+
+	cat <<-EOF > "$BITCOIN_DATA/bitcoin.conf"
+	${CONFIG_PREFIX}
+	printtoconsole=1
+	rpcallowip=::/0
+	${BITCOIN_EXTRA_ARGS}
+	EOF
+	chown bitcoin:bitcoin "$BITCOIN_DATA/bitcoin.conf"
+
+	if [[ "${BITCOIN_TORCONTROL}" ]]; then
+		# Because bitcoind only accept torcontrol= host as an ip only, we resolve it here and add to config
+		TOR_CONTROL_HOST=$(echo ${BITCOIN_TORCONTROL} | cut -d ':' -f 1)
+		TOR_CONTROL_PORT=$(echo ${BITCOIN_TORCONTROL} | cut -d ':' -f 2)
+		if [[ "$TOR_CONTROL_HOST" ]] && [[ "$TOR_CONTROL_PORT" ]]; then
+			TOR_IP=$(getent hosts $TOR_CONTROL_HOST | cut -d ' ' -f 1)
+			echo "torcontrol=$TOR_IP:$TOR_CONTROL_PORT" >> "$BITCOIN_DATA/bitcoin.conf"
+			echo "Added "torcontrol=$TOR_IP:$TOR_CONTROL_PORT" to $BITCOIN_DATA/bitcoin.conf"
+		else
+			echo "Invalid BITCOIN_TORCONTROL"
+		fi
+	fi
+
+	# ensure correct ownership and linking of data directory
+	# we do not update group ownership here, in case users want to mount
+	# a host directory and still retain access to it
+	chown -R bitcoin "$BITCOIN_DATA"
+	ln -sfn "$BITCOIN_DATA" /home/bitcoin/.bitcoin
+	chown -h bitcoin:bitcoin /home/bitcoin/.bitcoin
+	rm -f /home/bitcoin/.bitcoin/settings.json
+
+	if [[ "${need_migrate}" == "true" ]]; then
+		echo "Migrating legacy bitcoin wallet..."
+		gosu bitcoin "$@" &
+		BITCOIN_PID=$!
+		gosu bitcoin bitcoin-cli -datadir="${BITCOIN_DATA}" -rpcwait migratewallet "${WALLET_NAME}"
+		gosu bitcoin bitcoin-cli -datadir="${BITCOIN_DATA}" -rpcwait stop
+		wait "${BITCOIN_PID}"
+		echo "Bitcoin legacy wallet migrated."
+	fi
+
+	exec gosu bitcoin "$@"
+else
+	exec "$@"
+fi

--- a/Bitcoin/31.1/linuxamd64.Dockerfile
+++ b/Bitcoin/31.1/linuxamd64.Dockerfile
@@ -1,0 +1,46 @@
+FROM debian:bookworm-slim as builder
+
+RUN set -ex \
+	&& apt-get update \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu wget
+
+ENV BITCOIN_VERSION 31.1
+ENV BITCOIN_URL https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz
+ENV BITCOIN_SHA256 b80d9c3e04da78fb6f0569685673418cf686fadba9042d926d13fb87ff503f9e
+
+# install bitcoin binaries
+RUN set -ex \
+	&& cd /tmp \
+	&& wget -qO bitcoin.tar.gz "$BITCOIN_URL" \
+	&& echo "$BITCOIN_SHA256 bitcoin.tar.gz" | sha256sum -c - \
+	&& mkdir bin \
+	&& tar -xzvf bitcoin.tar.gz -C /tmp/bin --strip-components=2 "bitcoin-$BITCOIN_VERSION/bin/bitcoin-cli" "bitcoin-$BITCOIN_VERSION/bin/bitcoind" "bitcoin-$BITCOIN_VERSION/bin/bitcoin-wallet" \
+	&& cd bin \
+	&& wget -qO gosu "https://github.com/tianon/gosu/releases/download/1.16/gosu-amd64" \
+	&& echo "3a4e1fc7430f9e7dd7b0cbbe0bfde26bf4a250702e84cf48a1eb2b631c64cf13 gosu" | sha256sum -c -
+
+FROM debian:bookworm-slim
+COPY --from=builder "/tmp/bin" /usr/local/bin
+
+ARG BITCOIN_USER_ID=999
+ARG BITCOIN_GROUP_ID=999
+
+RUN apt-get update && \
+    apt-get install -qq --no-install-recommends xxd && \
+    rm -rf /var/lib/apt/lists/*
+RUN chmod +x /usr/local/bin/gosu && groupadd -r -g $BITCOIN_GROUP_ID bitcoin && useradd -r -m -u $BITCOIN_USER_ID -g bitcoin bitcoin
+
+# create data directory
+ENV BITCOIN_DATA /data
+RUN mkdir "$BITCOIN_DATA" \
+	&& chown -R bitcoin:bitcoin "$BITCOIN_DATA" \
+	&& ln -sfn "$BITCOIN_DATA" /home/bitcoin/.bitcoin \
+	&& chown -h bitcoin:bitcoin /home/bitcoin/.bitcoin
+
+VOLUME /data
+
+COPY docker-entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
+EXPOSE 8332 8333 18332 18333 18443 18444
+CMD ["bitcoind"]

--- a/Bitcoin/31.1/linuxarm32v7.Dockerfile
+++ b/Bitcoin/31.1/linuxarm32v7.Dockerfile
@@ -1,0 +1,51 @@
+# Use manifest image which support all architecture
+FROM debian:bookworm-slim as builder
+
+RUN set -ex \
+	&& apt-get update \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu wget
+RUN apt-get install -qq --no-install-recommends qemu-user-static binfmt-support
+
+ENV BITCOIN_VERSION 31.1
+ENV BITCOIN_URL https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-arm-linux-gnueabihf.tar.gz
+ENV BITCOIN_SHA256 66b2b45359efa161031a49898f96aa7cf1455db46ca6102acd16a7197dc3b96f
+
+# install bitcoin binaries
+RUN set -ex \
+	&& cd /tmp \
+	&& wget -qO bitcoin.tar.gz "$BITCOIN_URL" \
+	&& echo "$BITCOIN_SHA256 bitcoin.tar.gz" | sha256sum -c - \
+	&& mkdir bin \
+	&& tar -xzvf bitcoin.tar.gz -C /tmp/bin --strip-components=2 "bitcoin-$BITCOIN_VERSION/bin/bitcoin-cli" "bitcoin-$BITCOIN_VERSION/bin/bitcoind" "bitcoin-$BITCOIN_VERSION/bin/bitcoin-wallet" \
+	&& cd bin \
+	&& wget -qO gosu "https://github.com/tianon/gosu/releases/download/1.16/gosu-armhf" \
+	&& echo "1b670d5426e1ddbb14a14280afb6850a48c219189d4cfe7e6eb2cc08a4fc7785 gosu" | sha256sum -c -
+
+# Making sure the builder build an arm image despite being x64
+FROM --platform=arm debian:bookworm-slim
+
+COPY --from=builder "/tmp/bin" /usr/local/bin
+COPY --from=builder /usr/bin/qemu-arm-static /usr/bin/qemu-arm-static
+
+ARG BITCOIN_USER_ID=999
+ARG BITCOIN_GROUP_ID=999
+
+RUN apt-get update && \
+    apt-get install -qq --no-install-recommends xxd && \
+    rm -rf /var/lib/apt/lists/*
+RUN chmod +x /usr/local/bin/gosu && groupadd -r -g $BITCOIN_GROUP_ID bitcoin && useradd -r -m -u $BITCOIN_USER_ID -g bitcoin bitcoin
+
+# create data directory
+ENV BITCOIN_DATA /data
+RUN mkdir "$BITCOIN_DATA" \
+	&& chown -R bitcoin:bitcoin "$BITCOIN_DATA" \
+	&& ln -sfn "$BITCOIN_DATA" /home/bitcoin/.bitcoin \
+	&& chown -h bitcoin:bitcoin /home/bitcoin/.bitcoin
+
+VOLUME /data
+
+COPY docker-entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
+EXPOSE 8332 8333 18332 18333 18443 18444
+CMD ["bitcoind"]

--- a/Bitcoin/31.1/linuxarm32v7.Dockerfile
+++ b/Bitcoin/31.1/linuxarm32v7.Dockerfile
@@ -3,8 +3,7 @@ FROM debian:bookworm-slim as builder
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu wget
-RUN apt-get install -qq --no-install-recommends qemu-user-static binfmt-support
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu wget qemu-user-static binfmt-support
 
 ENV BITCOIN_VERSION 31.1
 ENV BITCOIN_URL https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-arm-linux-gnueabihf.tar.gz

--- a/Bitcoin/31.1/linuxarm64v8.Dockerfile
+++ b/Bitcoin/31.1/linuxarm64v8.Dockerfile
@@ -3,8 +3,7 @@ FROM debian:bookworm-slim as builder
 
 RUN set -ex \
 	&& apt-get update \
-	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu wget
-RUN apt-get install -qq --no-install-recommends qemu-user-static binfmt-support
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu wget qemu-user-static binfmt-support
 
 ENV BITCOIN_VERSION 31.1
 ENV BITCOIN_URL https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-aarch64-linux-gnu.tar.gz

--- a/Bitcoin/31.1/linuxarm64v8.Dockerfile
+++ b/Bitcoin/31.1/linuxarm64v8.Dockerfile
@@ -1,0 +1,51 @@
+# Use manifest image which support all architecture
+FROM debian:bookworm-slim as builder
+
+RUN set -ex \
+	&& apt-get update \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu wget
+RUN apt-get install -qq --no-install-recommends qemu-user-static binfmt-support
+
+ENV BITCOIN_VERSION 31.1
+ENV BITCOIN_URL https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-aarch64-linux-gnu.tar.gz
+ENV BITCOIN_SHA256 dcf1873f2208ba4f962f3398d47e154c39c0084be8f4553e05c940d0ace3d004
+
+# install bitcoin binaries
+RUN set -ex \
+	&& cd /tmp \
+	&& wget -qO bitcoin.tar.gz "$BITCOIN_URL" \
+	&& echo "$BITCOIN_SHA256 bitcoin.tar.gz" | sha256sum -c - \
+	&& mkdir bin \
+	&& tar -xzvf bitcoin.tar.gz -C /tmp/bin --strip-components=2 "bitcoin-$BITCOIN_VERSION/bin/bitcoin-cli" "bitcoin-$BITCOIN_VERSION/bin/bitcoind" "bitcoin-$BITCOIN_VERSION/bin/bitcoin-wallet" \
+	&& cd bin \
+	&& wget -qO gosu "https://github.com/tianon/gosu/releases/download/1.16/gosu-arm64" \
+	&& echo "23fa49907d5246d2e257de3bf883f57fba47fe1f559f7e732ff16c0f23d2b6a6 gosu" | sha256sum -c -
+
+# Making sure the builder build an arm image despite being x64
+FROM --platform=arm64 debian:bookworm-slim
+
+COPY --from=builder "/tmp/bin" /usr/local/bin
+COPY --from=builder /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
+
+ARG BITCOIN_USER_ID=999
+ARG BITCOIN_GROUP_ID=999
+
+RUN apt-get update && \
+    apt-get install -qq --no-install-recommends xxd && \
+    rm -rf /var/lib/apt/lists/*
+RUN chmod +x /usr/local/bin/gosu && groupadd -r -g $BITCOIN_GROUP_ID bitcoin && useradd -r -m -u $BITCOIN_USER_ID -g bitcoin bitcoin
+
+# create data directory
+ENV BITCOIN_DATA /data
+RUN mkdir "$BITCOIN_DATA" \
+	&& chown -R bitcoin:bitcoin "$BITCOIN_DATA" \
+	&& ln -sfn "$BITCOIN_DATA" /home/bitcoin/.bitcoin \
+	&& chown -h bitcoin:bitcoin /home/bitcoin/.bitcoin
+
+VOLUME /data
+
+COPY docker-entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
+EXPOSE 8332 8333 18332 18333 18443 18444
+CMD ["bitcoind"]


### PR DESCRIPTION
## Summary

- Update Bitcoin Core from 31.0 to 31.1.
- Limit automatic legacy wallet migration startup to `bitcoind`; `bitcoin-cli` invocations no longer attempt to launch migration.