### PR TITLE
Bump PostgreSQL to 18.6

### DIFF
--- a/Postgres/18.6/linuxamd64.Dockerfile
+++ b/Postgres/18.6/linuxamd64.Dockerfile
@@ -1,0 +1,15 @@
+FROM  postgres:18.6
+
+ENV PREVIOUS_VERSION 13
+RUN cp /etc/apt/sources.list.d/pgdg.list /etc/apt/sources.list.d/pgdg.list.backup && \
+    sed -i "s/$/ $PREVIOUS_VERSION/" /etc/apt/sources.list.d/pgdg.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+    postgresql-$PREVIOUS_VERSION \
+    postgresql-contrib-$PREVIOUS_VERSION && \
+    rm /etc/apt/sources.list.d/pgdg.list && mv /etc/apt/sources.list.d/pgdg.list.backup /etc/apt/sources.list.d/pgdg.list && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY scripts /scripts
+ENTRYPOINT ["/scripts/migrate-docker-entrypoint.sh"]
+CMD ["postgres"]

--- a/Postgres/18.6/linuxarm32v7.Dockerfile
+++ b/Postgres/18.6/linuxarm32v7.Dockerfile
@@ -1,0 +1,29 @@
+FROM  postgres:18.6 as downloader
+
+RUN set -ex \
+	&& apt-get update \
+	&& apt-get install -qq --no-install-recommends qemu-user-static binfmt-support
+
+FROM --platform=arm postgres:18.6
+COPY --from=downloader /usr/bin/qemu-arm-static /usr/bin/qemu-arm-static
+
+# Postgres doesn't ship packages for 13
+ENV PREVIOUS_VERSION 13
+RUN FALLBACK="http://aois.blob.core.windows.net/public/$PREVIOUS_VERSION-$(uname -m).tar.gz" && \
+    FALLBACK_SHARE="http://aois.blob.core.windows.net/public/share-$PREVIOUS_VERSION-$(uname -m).tar.gz" && \
+    apt-get update && apt-get install  --no-install-recommends -y wget && \
+    rm -rf /var/lib/apt/lists/* && \
+    cd /usr/lib/postgresql && \
+    wget $FALLBACK && \
+    echo "250773d9a043478530b8b1c705bffb29205b5eb9e6bdcfac1882f32efd5c6ab5 $PREVIOUS_VERSION-$(uname -m).tar.gz" | sha256sum -c - && \
+    tar -xvf *.tar.gz && \
+    rm -f *.tar.gz && \
+    cd /usr/share/postgresql && \
+    wget $FALLBACK_SHARE && \
+    echo "7753d7dbc5856f45120a45ad05d25a27e5d3e4f5940ca9371b1f2c8fba701317 share-$PREVIOUS_VERSION-$(uname -m).tar.gz" | sha256sum -c - && \
+    tar -xvf *.tar.gz && \
+    rm -f *.tar.gz
+
+COPY scripts /scripts
+ENTRYPOINT ["/scripts/migrate-docker-entrypoint.sh"]
+CMD ["postgres"]

--- a/Postgres/18.6/linuxarm64v8.Dockerfile
+++ b/Postgres/18.6/linuxarm64v8.Dockerfile
@@ -1,0 +1,22 @@
+FROM  postgres:18.6 as downloader
+
+RUN set -ex \
+	&& apt-get update \
+	&& apt-get install -qq --no-install-recommends qemu-user-static binfmt-support
+
+FROM --platform=arm64 postgres:18.6
+COPY --from=downloader /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
+
+ENV PREVIOUS_VERSION 13
+RUN cp /etc/apt/sources.list.d/pgdg.list /etc/apt/sources.list.d/pgdg.list.backup && \
+    sed -i "s/$/ $PREVIOUS_VERSION/" /etc/apt/sources.list.d/pgdg.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+    postgresql-$PREVIOUS_VERSION \
+    postgresql-contrib-$PREVIOUS_VERSION && \
+    rm /etc/apt/sources.list.d/pgdg.list && mv /etc/apt/sources.list.d/pgdg.list.backup /etc/apt/sources.list.d/pgdg.list && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY scripts /scripts
+ENTRYPOINT ["/scripts/migrate-docker-entrypoint.sh"]
+CMD ["postgres"]

--- a/Postgres/18.6/scripts/migrate-docker-entrypoint.sh
+++ b/Postgres/18.6/scripts/migrate-docker-entrypoint.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -Eeo pipefail
+shopt -s extglob
+
+if [ -d "/var/lib/postgresql/data" ]; then
+  echo "Error: You are mounting the volumes on '/var/lib/postgresql/data', it should be '/var/lib/postgresql' instead"
+  exit 1
+fi
+
+CURRENT_PGVERSION=""
+EXPECTED_PGVERSION="$PG_MAJOR"
+
+# /var/lib/postgresql/18/docker
+export PGDATANEW="$PGDATA"
+PGMOUNT="/var/lib/postgresql"
+export PGDATAOLD=""
+
+if [[ -f "$PGMOUNT/PG_VERSION" ]]; then
+    CURRENT_PGVERSION="$(cat $PGMOUNT/PG_VERSION)"
+    PGDATAOLD="$PGMOUNT/${CURRENT_PGVERSION}/docker"
+    mkdir -p "$PGDATAOLD"
+
+    for d in "$PGMOUNT"/*; do
+        [[ "$d" == "$PGMOUNT/$CURRENT_PGVERSION" ]] && continue
+        [[ "$d" == "$PGDATANEW" ]] && continue
+        mv "$d" "$PGDATAOLD/"
+    done
+
+    cp "$PGDATAOLD/PG_VERSION" "$PGMOUNT/PG_MIGRATING_FROM_VERSION"
+
+elif [[ -f "$PGMOUNT/PG_MIGRATING_FROM_VERSION" ]]; then
+    echo "Previous migration failed"
+    CURRENT_PGVERSION="$(cat $PGMOUNT/PG_MIGRATING_FROM_VERSION)"
+    PGDATAOLD="$PGMOUNT/${CURRENT_PGVERSION}/docker"
+fi
+
+if [[ "$CURRENT_PGVERSION" != "$EXPECTED_PGVERSION" ]] && \
+   [[ "$CURRENT_PGVERSION" != "" ]]; then
+
+    if ! [ -f "/usr/lib/postgresql/$CURRENT_PGVERSION/bin/pg_upgrade" ]; then
+        echo "Trying to install Postgres $CURRENT_PGVERSION migration tools"
+        sed -i "s/$/ $CURRENT_PGVERSION/" /etc/apt/sources.list.d/pgdg.list
+        if ! apt-get update; then
+            echo "apt-get update failed. Are you using raspberry pi 4? If yes, please follow https://blog.samcater.com/fix-workaround-rpi4-docker-libseccomp2-docker-20/"
+            exit 1
+        fi
+        if ! apt-get install -y --no-install-recommends \
+                postgresql-$CURRENT_PGVERSION \
+                postgresql-contrib-$CURRENT_PGVERSION; then
+                # On arm32, postgres doesn't ship those packages, so we download
+                # the binaries from an archive we built from the postgres 9.6.20 image's binaries
+                FALLBACK="https://aois.blob.core.windows.net/public/$CURRENT_PGVERSION-$(uname -m).tar.gz"
+                FALLBACK_SHARE="https://aois.blob.core.windows.net/public/share-$CURRENT_PGVERSION-$(uname -m).tar.gz"
+                echo "Failure to install postgresql-$CURRENT_PGVERSION and postgresql-contrib-$CURRENT_PGVERSION trying fallback $FALLBACK"
+                apt-get install -y wget
+                pushd . > /dev/null
+                cd /usr/lib/postgresql
+                wget $FALLBACK
+                tar -xvf *.tar.gz
+                rm -f *.tar.gz
+                cd /usr/share/postgresql
+                wget $FALLBACK_SHARE
+                tar -xvf *.tar.gz
+                rm -f *.tar.gz
+                popd > /dev/null
+                echo "Successfully installed PG utilities via the fallback"
+        fi
+    else
+        echo "Migration binaries already present on the image"
+    fi
+
+    export PGBINOLD="/usr/lib/postgresql/$CURRENT_PGVERSION/bin"
+
+    mkdir -p "$PGDATANEW" "$PGDATAOLD"
+    chmod 700 "$PGDATAOLD" "$PGDATANEW"
+    chown postgres .
+    chown -R postgres "$PGDATAOLD" "$PGDATANEW" "$PGMOUNT"
+
+    [[ "$POSTGRES_USER" ]] && export PGUSER="$POSTGRES_USER"
+    [[ "$POSTGRES_PASSWORD" ]] && export PGPASSWORD="$POSTGRES_PASSWORD"
+    if [ ! -s "$PGDATANEW/PG_VERSION" ]; then
+        if [[ "$PGUSER" ]]; then
+            PGDATA="$PGDATANEW" eval "gosu postgres initdb -U$PGUSER $POSTGRES_INITDB_ARGS"
+        else
+            PGDATA="$PGDATANEW" eval "gosu postgres initdb $POSTGRES_INITDB_ARGS"
+        fi
+         gosu postgres pg_checksums --check -D "$PGDATAOLD" &> /dev/null || gosu postgres pg_checksums --disable --pgdata "$PGDATANEW"
+	fi
+
+    rm -rf "$PGDATANEW/pg_upgrade_output.d"
+    if ! gosu postgres pg_upgrade --link; then
+        echo "Failed to upgrade the server"
+        find "$PGDATANEW/pg_upgrade_output.d" -type f -name 'pg_upgrade_server.log' -exec cp -t "$PGMOUNT" {} +
+        cat "$PGMOUNT/pg_upgrade_server.log"
+        if [ -f "$PGDATAOLD/PG_VERSION" ] && [ -f "$PGDATANEW/PG_VERSION" ]; then
+            echo "Cleaning up the new cluster"
+            rm -r $PGDATANEW/*
+        fi
+
+        if grep -Fq 'must be superuser to connect in binary upgrade mode' "$PGMOUNT/pg_upgrade_server.log"; then
+            echo "Attempt to add SUPERUSER role to postgres user..."
+            gosu postgres "$PGBINOLD/postgres" --single -D "$PGDATAOLD" postgres <<'SQL'
+            ALTER ROLE postgres WITH SUPERUSER;
+SQL
+            exit 1
+        fi
+
+        # If the db hasn't started cleanly, this may solve it.
+        echo "Attempt to start/stop the old cluster if it hasn't exit cleanly"
+        gosu postgres $PGBINOLD/pg_ctl start -w -D $PGDATAOLD
+        gosu postgres $PGBINOLD/pg_ctl stop -w -D $PGDATAOLD
+
+        exit 1
+    fi
+
+    echo "pg_upgrade ran successfully, creating NEED_POST_MIGRATE, removing PG_MIGRATING_FROM_VERSION"
+    touch "$PGMOUNT/NEED_POST_MIGRATE"
+    rm "$PGMOUNT/PG_MIGRATING_FROM_VERSION"
+    rm $PGDATANEW/*.conf
+    mv $PGDATAOLD/*.conf "$PGDATANEW"
+
+    rm -rf "$PGMOUNT/${CURRENT_PGVERSION}"
+
+    unset CURRENT_PGVERSION
+    unset PGPASSWORD
+    unset PGUSER
+fi
+
+if [[ -f "$PGMOUNT/NEED_POST_MIGRATE" ]]; then
+    [[ "$POSTGRES_USER" ]] && export PGUSER="$POSTGRES_USER"
+    [[ "$POSTGRES_PASSWORD" ]] && export PGPASSWORD="$POSTGRES_PASSWORD"
+    echo "Running post-migrate.sh..."
+    gosu postgres bash /scripts/post-migrate.sh
+    rm "$PGMOUNT/NEED_POST_MIGRATE"
+    unset PGPASSWORD
+    unset PGUSER
+fi
+
+if [ -f "docker-entrypoint.sh" ]; then
+    exec ./docker-entrypoint.sh  "$@"
+else
+    exec docker-entrypoint.sh  "$@"
+fi

--- a/Postgres/18.6/scripts/migrate-docker-entrypoint.sh
+++ b/Postgres/18.6/scripts/migrate-docker-entrypoint.sh
@@ -16,7 +16,11 @@ PGMOUNT="/var/lib/postgresql"
 export PGDATAOLD=""
 
 if [[ -f "$PGMOUNT/PG_VERSION" ]]; then
-    CURRENT_PGVERSION="$(cat $PGMOUNT/PG_VERSION)"
+    CURRENT_PGVERSION="$(cat "$PGMOUNT/PG_VERSION")"
+    if ! [[ "$CURRENT_PGVERSION" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+        echo "Error: Invalid PostgreSQL version marker: $CURRENT_PGVERSION"
+        exit 1
+    fi
     PGDATAOLD="$PGMOUNT/${CURRENT_PGVERSION}/docker"
     mkdir -p "$PGDATAOLD"
 
@@ -30,7 +34,11 @@ if [[ -f "$PGMOUNT/PG_VERSION" ]]; then
 
 elif [[ -f "$PGMOUNT/PG_MIGRATING_FROM_VERSION" ]]; then
     echo "Previous migration failed"
-    CURRENT_PGVERSION="$(cat $PGMOUNT/PG_MIGRATING_FROM_VERSION)"
+    CURRENT_PGVERSION="$(cat "$PGMOUNT/PG_MIGRATING_FROM_VERSION")"
+    if ! [[ "$CURRENT_PGVERSION" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+        echo "Error: Invalid PostgreSQL version marker: $CURRENT_PGVERSION"
+        exit 1
+    fi
     PGDATAOLD="$PGMOUNT/${CURRENT_PGVERSION}/docker"
 fi
 
@@ -94,7 +102,7 @@ if [[ "$CURRENT_PGVERSION" != "$EXPECTED_PGVERSION" ]] && \
         cat "$PGMOUNT/pg_upgrade_server.log"
         if [ -f "$PGDATAOLD/PG_VERSION" ] && [ -f "$PGDATANEW/PG_VERSION" ]; then
             echo "Cleaning up the new cluster"
-            rm -r $PGDATANEW/*
+            rm -rf -- "${PGDATANEW:?PGDATANEW must be set}"/*
         fi
 
         if grep -Fq 'must be superuser to connect in binary upgrade mode' "$PGMOUNT/pg_upgrade_server.log"; then
@@ -116,10 +124,10 @@ SQL
     echo "pg_upgrade ran successfully, creating NEED_POST_MIGRATE, removing PG_MIGRATING_FROM_VERSION"
     touch "$PGMOUNT/NEED_POST_MIGRATE"
     rm "$PGMOUNT/PG_MIGRATING_FROM_VERSION"
-    rm $PGDATANEW/*.conf
-    mv $PGDATAOLD/*.conf "$PGDATANEW"
+    rm -f -- "${PGDATANEW:?PGDATANEW must be set}"/*.conf
+    mv "$PGDATAOLD"/*.conf "$PGDATANEW"
 
-    rm -rf "$PGMOUNT/${CURRENT_PGVERSION}"
+    rm -rf -- "$PGMOUNT/${CURRENT_PGVERSION:?CURRENT_PGVERSION must be set}"
 
     unset CURRENT_PGVERSION
     unset PGPASSWORD

--- a/Postgres/18.6/scripts/post-migrate.sh
+++ b/Postgres/18.6/scripts/post-migrate.sh
@@ -1,0 +1,22 @@
+set -Eeo pipefail
+shopt -s extglob
+
+
+if [ "$(id -u)" = '0' ]; then
+	echo "Error: You need to run post-migrate.sh as postgres user"
+	exit 1
+fi
+
+source /usr/local/bin/docker-entrypoint.sh
+
+echo "Running vacuum analyze..."
+docker_temp_server_start "$@"
+
+if [[ -f "/update_extensions.sql" ]]; then
+	echo "Running extension update script: /update_extensions.sql"
+	psql --file="/update_extensions.sql"
+fi
+
+vacuumdb --all --analyze-only --missing-stats-only
+
+docker_temp_server_stop


### PR DESCRIPTION
## Summary

- Update PostgreSQL from 18.4 to 18.6; PostgreSQL 18.5 was not released.
- Include upstream fixes for 28 security vulnerabilities and more than 110 bugs.

## Compatibility

- Installations using third-party logical decoding plugins must add them to `output_plugin_libraries`; the new default permits only PostgreSQL-provided plugins.
- Tables with GIN indexes may have invalid `reltuples` values from earlier releases and may require `ANALYZE`.
- Affected `btree_gist` indexes on float or bit columns and extreme-length `ltree` indexes may require reindexing.

Upstream release notes: https://www.postgresql.org/docs/18/release-18-6.html

Upstream update guidance: https://www.postgresql.org/about/news/postgresql-186-1711-1615-1519-1424-and-19-beta-3-released-3365/