### PR TITLE
Add non-publishing image validation

### DIFF
--- a/.github/scripts/parse-tag.sh
+++ b/.github/scripts/parse-tag.sh
@@ -11,7 +11,7 @@
 # DOCKERHUB_DOCKEFILE_ARM32: Bitcoin/0.17.0/linuxarm32v7.Dockerfile
 # DOCKERHUB_DOCKEFILE_AMD64: Bitcoin/0.17.0/linuxamd64.Dockerfile
 
-CI_TAG="${GITHUB_REF_NAME:-${CIRCLE_TAG:-}}"
+CI_TAG="${CI_TAG:-${GITHUB_REF_NAME:-${CIRCLE_TAG:-}}}"
 
 SEPARATOR=$(expr index "$CI_TAG" "/")
 NODE_NAME=${CI_TAG:0:$SEPARATOR-1}

--- a/.github/scripts/publish-manifest.sh
+++ b/.github/scripts/publish-manifest.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -euo pipefail
+
+DOCKER_HOST="${DOCKER_HOST:-}"
+source ".github/scripts/parse-tag.sh"
+
+DOCKER_ARGS=()
+if [ -n "$DOCKER_OPTIONS" ]; then
+    DOCKER_ARGS=("$DOCKER_OPTIONS")
+fi
+
+sudo docker "${DOCKER_ARGS[@]}" login --username="$DOCKERHUB_USER" --password="$DOCKERHUB_PASS"
+
+IMAGES=()
+if [ -f "$DOCKERHUB_DOCKEFILE_AMD64" ]; then
+    IMAGES+=("$DOCKERHUB_DESTINATION-amd64")
+fi
+if [ -f "$DOCKERHUB_DOCKEFILE_ARM64" ]; then
+    IMAGES+=("$DOCKERHUB_DESTINATION-arm64v8")
+fi
+if [ -f "$DOCKERHUB_DOCKEFILE_ARM32" ]; then
+    IMAGES+=("$DOCKERHUB_DESTINATION-arm32v7")
+fi
+
+if [ "${#IMAGES[@]}" -eq 0 ]; then
+    echo "Skipping $DOCKERHUB_DESTINATION as there were no supported platforms to build for"
+    exit 0
+fi
+
+sudo docker manifest create --amend "$DOCKERHUB_DESTINATION" "${IMAGES[@]}"
+if [ -f "$DOCKERHUB_DOCKEFILE_AMD64" ]; then
+    sudo docker "${DOCKER_ARGS[@]}" manifest annotate "$DOCKERHUB_DESTINATION" "$DOCKERHUB_DESTINATION-amd64" --os linux --arch amd64
+fi
+if [ -f "$DOCKERHUB_DOCKEFILE_ARM32" ]; then
+    sudo docker "${DOCKER_ARGS[@]}" manifest annotate "$DOCKERHUB_DESTINATION" "$DOCKERHUB_DESTINATION-arm32v7" --os linux --arch arm --variant v7
+fi
+if [ -f "$DOCKERHUB_DOCKEFILE_ARM64" ]; then
+    sudo docker "${DOCKER_ARGS[@]}" manifest annotate "$DOCKERHUB_DESTINATION" "$DOCKERHUB_DESTINATION-arm64v8" --os linux --arch arm64 --variant v8
+fi
+sudo docker "${DOCKER_ARGS[@]}" manifest push "$DOCKERHUB_DESTINATION" -p

--- a/.github/scripts/run-image.sh
+++ b/.github/scripts/run-image.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+set -euo pipefail
+
+IMAGE_TYPE="${1:?Image type is required}"
+MODE="${2:?Mode is required}"
+DOCKER_HOST="${DOCKER_HOST:-}"
+
+if [ "$MODE" != "build" ] && [ "$MODE" != "publish" ]; then
+    echo "Unsupported mode: $MODE" >&2
+    exit 1
+fi
+
+source ".github/scripts/parse-tag.sh"
+
+DOCKER_ARGS=()
+if [ -n "$DOCKER_OPTIONS" ]; then
+    DOCKER_ARGS=("$DOCKER_OPTIONS")
+fi
+
+case "$IMAGE_TYPE" in
+    linuxamd64)
+        DOCKERHUB_DOCKEFILE="$DOCKERHUB_DOCKEFILE_AMD64"
+        DOCKERHUB_DESTINATION="$DOCKERHUB_REPO:$LATEST_TAG-amd64"
+        ;;
+    linuxarm32v7)
+        DOCKERHUB_DOCKEFILE="$DOCKERHUB_DOCKEFILE_ARM32"
+        DOCKERHUB_DESTINATION="$DOCKERHUB_REPO:$LATEST_TAG-arm32v7"
+        ;;
+    linuxarm64v8)
+        DOCKERHUB_DOCKEFILE="$DOCKERHUB_DOCKEFILE_ARM64"
+        DOCKERHUB_DESTINATION="$DOCKERHUB_REPO:$LATEST_TAG-arm64v8"
+        ;;
+    buildx)
+        DOCKERHUB_DOCKEFILE="$DOCKERHUB_DOCKEFILE_BUILDX"
+        DOCKERHUB_DESTINATION="$DOCKERHUB_REPO:$LATEST_TAG"
+        ;;
+    *)
+        echo "Unsupported image type: $IMAGE_TYPE" >&2
+        exit 1
+        ;;
+esac
+
+if [ ! -f "$DOCKERHUB_DOCKEFILE" ]; then
+    echo "Skipping $IMAGE_TYPE because $DOCKERHUB_DOCKEFILE is not found"
+    exit 0
+fi
+
+if [ "$IMAGE_TYPE" = "linuxarm32v7" ]; then
+    sudo docker "${DOCKER_ARGS[@]}" run --rm --privileged multiarch/qemu-user-static:register --reset
+    if grep "#EnableQEMU" "$DOCKERHUB_DOCKEFILE"; then
+        sudo apt update
+        sudo apt install -y qemu-user-static qemu-user binfmt-support
+        sudo cp /usr/bin/qemu-arm-static "$(dirname "$DOCKERHUB_DOCKEFILE")/qemu-arm-static"
+        sed -i -e 's/#EnableQEMU //g' "$DOCKERHUB_DOCKEFILE"
+    fi
+elif [ "$IMAGE_TYPE" = "linuxarm64v8" ]; then
+    sudo docker "${DOCKER_ARGS[@]}" run --rm --privileged multiarch/qemu-user-static:register --reset
+    sudo apt update
+    sudo apt install -y qemu-user-static qemu-user binfmt-support
+    sudo cp /usr/bin/qemu-aarch64-static "$(dirname "$DOCKERHUB_DOCKEFILE")/qemu-aarch64-static"
+    sed -i -e 's/#EnableQEMU //g' "$DOCKERHUB_DOCKEFILE"
+fi
+
+if [ "$MODE" = "publish" ]; then
+    if [ "$IMAGE_TYPE" = "buildx" ]; then
+        source ".github/scripts/push-image-buildx.sh"
+    else
+        source ".github/scripts/push-image.sh"
+    fi
+elif [ "$IMAGE_TYPE" = "buildx" ]; then
+    docker buildx build \
+        --platform linux/amd64,linux/arm64,linux/arm/v7 \
+        -f "$DOCKERHUB_DOCKEFILE" \
+        -t "$DOCKERHUB_DESTINATION" \
+        "$NODE_NAME/$NODE_VERSION"
+else
+    sudo docker "${DOCKER_ARGS[@]}" build --pull \
+        -t "$DOCKERHUB_DESTINATION" \
+        -f "$DOCKERHUB_DOCKEFILE" \
+        "$NODE_NAME/$NODE_VERSION"
+fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,5 @@
 name: Publish Docker Images
+run-name: ${{ inputs.tag || github.ref_name }} (${{ github.event_name == 'workflow_dispatch' && 'Build Only' || 'Build and Push' }})
 
 on:
   push:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,181 +17,36 @@ env:
   CI_TAG: ${{ inputs.tag || github.ref_name }}
 
 jobs:
-  publish_linuxamd64:
-    name: Publish linux/amd64
+  publish_images:
+    name: Publish ${{ matrix.name }}
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Build image
-        if: github.event_name == 'workflow_dispatch'
-        shell: bash
-        run: |
-          source ".github/scripts/parse-tag.sh"
-          DOCKER_ARGS=()
-          if [ -n "$DOCKER_OPTIONS" ]; then
-              DOCKER_ARGS=("$DOCKER_OPTIONS")
-          fi
-          DOCKERHUB_DOCKEFILE="$DOCKERHUB_DOCKEFILE_AMD64"
-          DOCKERHUB_DESTINATION="$DOCKERHUB_REPO:$LATEST_TAG-amd64"
-          if [ -f "$DOCKERHUB_DOCKEFILE" ]; then
-              sudo docker "${DOCKER_ARGS[@]}" build --pull -t "$DOCKERHUB_DESTINATION" -f "$DOCKERHUB_DOCKEFILE" "$NODE_NAME/$NODE_VERSION"
-          else
-              echo "Skipping linuxamd64 because $DOCKERHUB_DOCKEFILE is not found"
-          fi
-
-      - name: Publish image
-        if: github.event_name == 'push'
-        env:
-          DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
-          DOCKERHUB_PASS: ${{ secrets.DOCKERHUB_PASS }}
-        shell: bash
-        run: |
-          source ".github/scripts/parse-tag.sh"
-          DOCKERHUB_DOCKEFILE="$DOCKERHUB_DOCKEFILE_AMD64"
-          DOCKERHUB_DESTINATION="$DOCKERHUB_REPO:$LATEST_TAG-amd64"
-          if [ -f "$DOCKERHUB_DOCKEFILE" ]; then
-              source ".github/scripts/push-image.sh"
-          else
-              echo "Skipping linuxamd64 because $DOCKERHUB_DOCKEFILE is not found"
-          fi
-
-  publish_linuxarm32v7:
-    name: Publish linux/arm/v7
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Build image
-        if: github.event_name == 'workflow_dispatch'
-        shell: bash
-        run: |
-          source ".github/scripts/parse-tag.sh"
-          DOCKER_ARGS=()
-          if [ -n "$DOCKER_OPTIONS" ]; then
-              DOCKER_ARGS=("$DOCKER_OPTIONS")
-          fi
-          DOCKERHUB_DOCKEFILE="$DOCKERHUB_DOCKEFILE_ARM32"
-          DOCKERHUB_DESTINATION="$DOCKERHUB_REPO:$LATEST_TAG-arm32v7"
-          if [ -f "$DOCKERHUB_DOCKEFILE" ]; then
-              sudo docker "${DOCKER_ARGS[@]}" run --rm --privileged multiarch/qemu-user-static:register --reset
-              if grep "#EnableQEMU" "$DOCKERHUB_DOCKEFILE"; then
-                  sudo apt update
-                  sudo apt install -y qemu-user-static qemu-user binfmt-support
-                  sudo cp /usr/bin/qemu-arm-static "$(dirname "$DOCKERHUB_DOCKEFILE")/qemu-arm-static"
-                  sed -i -e 's/#EnableQEMU //g' "$DOCKERHUB_DOCKEFILE"
-              fi
-              sudo docker "${DOCKER_ARGS[@]}" build --pull -t "$DOCKERHUB_DESTINATION" -f "$DOCKERHUB_DOCKEFILE" "$NODE_NAME/$NODE_VERSION"
-          else
-              echo "Skipping linuxarm32v7 because $DOCKERHUB_DOCKEFILE is not found"
-          fi
-
-      - name: Publish image
-        if: github.event_name == 'push'
-        env:
-          DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
-          DOCKERHUB_PASS: ${{ secrets.DOCKERHUB_PASS }}
-        shell: bash
-        run: |
-          source ".github/scripts/parse-tag.sh"
-          DOCKER_ARGS=()
-          if [ -n "$DOCKER_OPTIONS" ]; then
-              DOCKER_ARGS=("$DOCKER_OPTIONS")
-          fi
-          DOCKERHUB_DOCKEFILE="$DOCKERHUB_DOCKEFILE_ARM32"
-          DOCKERHUB_DESTINATION="$DOCKERHUB_REPO:$LATEST_TAG-arm32v7"
-          if [ -f "$DOCKERHUB_DOCKEFILE" ]; then
-              sudo docker "${DOCKER_ARGS[@]}" run --rm --privileged multiarch/qemu-user-static:register --reset
-              if grep "#EnableQEMU" "$DOCKERHUB_DOCKEFILE"; then
-                  sudo apt update
-                  sudo apt install -y qemu-user-static qemu-user binfmt-support
-                  sudo cp /usr/bin/qemu-arm-static "$(dirname "$DOCKERHUB_DOCKEFILE")/qemu-arm-static"
-                  sed -i -e 's/#EnableQEMU //g' "$DOCKERHUB_DOCKEFILE"
-              fi
-              source ".github/scripts/push-image.sh"
-          else
-              echo "Skipping linuxarm32v7 because $DOCKERHUB_DOCKEFILE is not found"
-          fi
-
-  publish_linuxarm64v8:
-    name: Publish linux/arm64/v8
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Build image
-        if: github.event_name == 'workflow_dispatch'
-        shell: bash
-        run: |
-          source ".github/scripts/parse-tag.sh"
-          DOCKER_ARGS=()
-          if [ -n "$DOCKER_OPTIONS" ]; then
-              DOCKER_ARGS=("$DOCKER_OPTIONS")
-          fi
-          DOCKERHUB_DOCKEFILE="$DOCKERHUB_DOCKEFILE_ARM64"
-          DOCKERHUB_DESTINATION="$DOCKERHUB_REPO:$LATEST_TAG-arm64v8"
-          if [ -f "$DOCKERHUB_DOCKEFILE" ]; then
-              sudo docker "${DOCKER_ARGS[@]}" run --rm --privileged multiarch/qemu-user-static:register --reset
-              sudo apt update
-              sudo apt install -y qemu-user-static qemu-user binfmt-support
-              sudo cp /usr/bin/qemu-aarch64-static "$(dirname "$DOCKERHUB_DOCKEFILE")/qemu-aarch64-static"
-              sed -i -e 's/#EnableQEMU //g' "$DOCKERHUB_DOCKEFILE"
-              sudo docker "${DOCKER_ARGS[@]}" build --pull -t "$DOCKERHUB_DESTINATION" -f "$DOCKERHUB_DOCKEFILE" "$NODE_NAME/$NODE_VERSION"
-          else
-              echo "Skipping linuxarm64v8 because $DOCKERHUB_DOCKEFILE is not found"
-          fi
-
-      - name: Publish image
-        if: github.event_name == 'push'
-        env:
-          DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
-          DOCKERHUB_PASS: ${{ secrets.DOCKERHUB_PASS }}
-        shell: bash
-        run: |
-          source ".github/scripts/parse-tag.sh"
-          DOCKER_ARGS=()
-          if [ -n "$DOCKER_OPTIONS" ]; then
-              DOCKER_ARGS=("$DOCKER_OPTIONS")
-          fi
-          DOCKERHUB_DOCKEFILE="$DOCKERHUB_DOCKEFILE_ARM64"
-          DOCKERHUB_DESTINATION="$DOCKERHUB_REPO:$LATEST_TAG-arm64v8"
-          if [ -f "$DOCKERHUB_DOCKEFILE" ]; then
-              sudo docker "${DOCKER_ARGS[@]}" run --rm --privileged multiarch/qemu-user-static:register --reset
-              sudo apt update
-              sudo apt install -y qemu-user-static qemu-user binfmt-support
-              sudo cp /usr/bin/qemu-aarch64-static "$(dirname "$DOCKERHUB_DOCKEFILE")/qemu-aarch64-static"
-              sed -i -e 's/#EnableQEMU //g' "$DOCKERHUB_DOCKEFILE"
-              source ".github/scripts/push-image.sh"
-          else
-              echo "Skipping linuxarm64v8 because $DOCKERHUB_DOCKEFILE is not found"
-          fi
-
-  publish_buildx:
-    name: Publish buildx image
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: linuxamd64
+            name: linux/amd64
+          - image: linuxarm32v7
+            name: linux/arm/v7
+          - image: linuxarm64v8
+            name: linux/arm64/v8
+          - image: buildx
+            name: buildx image
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up QEMU
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch' && matrix.image == 'buildx'
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch' && matrix.image == 'buildx'
         uses: docker/setup-buildx-action@v3
 
       - name: Build image
         if: github.event_name == 'workflow_dispatch'
         shell: bash
-        run: |
-          source ".github/scripts/parse-tag.sh"
-          DOCKERHUB_DOCKEFILE="$DOCKERHUB_DOCKEFILE_BUILDX"
-          DOCKERHUB_DESTINATION="$DOCKERHUB_REPO:$LATEST_TAG"
-          if [ -f "$DOCKERHUB_DOCKEFILE" ]; then
-              docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -f "$DOCKERHUB_DOCKEFILE" -t "$DOCKERHUB_DESTINATION" "$NODE_NAME/$NODE_VERSION"
-          else
-              echo "Skipping buildx because $DOCKERHUB_DOCKEFILE_BUILDX is not found"
-          fi
+        run: .github/scripts/run-image.sh "${{ matrix.image }}" build
 
       - name: Publish image
         if: github.event_name == 'push'
@@ -199,25 +54,13 @@ jobs:
           DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
           DOCKERHUB_PASS: ${{ secrets.DOCKERHUB_PASS }}
         shell: bash
-        run: |
-          source ".github/scripts/parse-tag.sh"
-          DOCKERHUB_DOCKEFILE="$DOCKERHUB_DOCKEFILE_BUILDX"
-          DOCKERHUB_DESTINATION="$DOCKERHUB_REPO:$LATEST_TAG"
-          if [ -f "$DOCKERHUB_DOCKEFILE" ]; then
-              source ".github/scripts/push-image-buildx.sh"
-          else
-              echo "Skipping buildx because $DOCKERHUB_DOCKEFILE_BUILDX is not found"
-          fi
+        run: .github/scripts/run-image.sh "${{ matrix.image }}" publish
 
   publish_multiarch:
     name: Publish multi-arch manifest
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
-    needs:
-      - publish_linuxamd64
-      - publish_linuxarm32v7
-      - publish_linuxarm64v8
-      - publish_buildx
+    needs: publish_images
     steps:
       - uses: actions/checkout@v4
 
@@ -226,35 +69,4 @@ jobs:
           DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
           DOCKERHUB_PASS: ${{ secrets.DOCKERHUB_PASS }}
         shell: bash
-        run: |
-          source ".github/scripts/parse-tag.sh"
-          DOCKER_ARGS=()
-          if [ -n "$DOCKER_OPTIONS" ]; then
-              DOCKER_ARGS=("$DOCKER_OPTIONS")
-          fi
-          sudo docker "${DOCKER_ARGS[@]}" login --username="$DOCKERHUB_USER" --password="$DOCKERHUB_PASS"
-          IMAGES=()
-          if [ -f "$DOCKERHUB_DOCKEFILE_AMD64" ]; then
-              IMAGES+=("$DOCKERHUB_DESTINATION-amd64")
-          fi
-          if [ -f "$DOCKERHUB_DOCKEFILE_ARM64" ]; then
-              IMAGES+=("$DOCKERHUB_DESTINATION-arm64v8")
-          fi
-          if [ -f "$DOCKERHUB_DOCKEFILE_ARM32" ]; then
-              IMAGES+=("$DOCKERHUB_DESTINATION-arm32v7")
-          fi
-          if [ "${#IMAGES[@]}" -eq 0 ]; then
-              echo "Skipping $DOCKERHUB_DESTINATION as there were no supported platforms to build for"
-          else
-              sudo docker manifest create --amend "$DOCKERHUB_DESTINATION" "${IMAGES[@]}"
-              if [ -f "$DOCKERHUB_DOCKEFILE_AMD64" ]; then
-                  sudo docker "${DOCKER_ARGS[@]}" manifest annotate "$DOCKERHUB_DESTINATION" "$DOCKERHUB_DESTINATION-amd64" --os linux --arch amd64
-              fi
-              if [ -f "$DOCKERHUB_DOCKEFILE_ARM32" ]; then
-                  sudo docker "${DOCKER_ARGS[@]}" manifest annotate "$DOCKERHUB_DESTINATION" "$DOCKERHUB_DESTINATION-arm32v7" --os linux --arch arm --variant v7
-              fi
-              if [ -f "$DOCKERHUB_DOCKEFILE_ARM64" ]; then
-                  sudo docker "${DOCKER_ARGS[@]}" manifest annotate "$DOCKERHUB_DESTINATION" "$DOCKERHUB_DESTINATION-arm64v8" --os linux --arch arm64 --variant v8
-              fi
-              sudo docker "${DOCKER_ARGS[@]}" manifest push "$DOCKERHUB_DESTINATION" -p
-          fi
+        run: .github/scripts/publish-manifest.sh

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   publish_images:
-    name: Publish ${{ matrix.name }}
+    name: Publish ${{ inputs.tag || github.ref_name }} (${{ matrix.name }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,12 +4,17 @@ on:
   push:
     tags:
       - '*/*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Image tag in Project/version format
+        required: true
+        type: string
 
 env:
   DOCKER_HOST: unix:///var/run/docker.sock
   DOCKER_CLI_EXPERIMENTAL: enabled
-  DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
-  DOCKERHUB_PASS: ${{ secrets.DOCKERHUB_PASS }}
+  CI_TAG: ${{ inputs.tag || github.ref_name }}
 
 jobs:
   publish_linuxamd64:
@@ -18,7 +23,28 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Build image
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        run: |
+          source ".github/scripts/parse-tag.sh"
+          DOCKER_ARGS=()
+          if [ -n "$DOCKER_OPTIONS" ]; then
+              DOCKER_ARGS=("$DOCKER_OPTIONS")
+          fi
+          DOCKERHUB_DOCKEFILE="$DOCKERHUB_DOCKEFILE_AMD64"
+          DOCKERHUB_DESTINATION="$DOCKERHUB_REPO:$LATEST_TAG-amd64"
+          if [ -f "$DOCKERHUB_DOCKEFILE" ]; then
+              sudo docker "${DOCKER_ARGS[@]}" build --pull -t "$DOCKERHUB_DESTINATION" -f "$DOCKERHUB_DOCKEFILE" "$NODE_NAME/$NODE_VERSION"
+          else
+              echo "Skipping linuxamd64 because $DOCKERHUB_DOCKEFILE is not found"
+          fi
+
       - name: Publish image
+        if: github.event_name == 'push'
+        env:
+          DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
+          DOCKERHUB_PASS: ${{ secrets.DOCKERHUB_PASS }}
         shell: bash
         run: |
           source ".github/scripts/parse-tag.sh"
@@ -36,7 +62,35 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Build image
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        run: |
+          source ".github/scripts/parse-tag.sh"
+          DOCKER_ARGS=()
+          if [ -n "$DOCKER_OPTIONS" ]; then
+              DOCKER_ARGS=("$DOCKER_OPTIONS")
+          fi
+          DOCKERHUB_DOCKEFILE="$DOCKERHUB_DOCKEFILE_ARM32"
+          DOCKERHUB_DESTINATION="$DOCKERHUB_REPO:$LATEST_TAG-arm32v7"
+          if [ -f "$DOCKERHUB_DOCKEFILE" ]; then
+              sudo docker "${DOCKER_ARGS[@]}" run --rm --privileged multiarch/qemu-user-static:register --reset
+              if grep "#EnableQEMU" "$DOCKERHUB_DOCKEFILE"; then
+                  sudo apt update
+                  sudo apt install -y qemu-user-static qemu-user binfmt-support
+                  sudo cp /usr/bin/qemu-arm-static "$(dirname "$DOCKERHUB_DOCKEFILE")/qemu-arm-static"
+                  sed -i -e 's/#EnableQEMU //g' "$DOCKERHUB_DOCKEFILE"
+              fi
+              sudo docker "${DOCKER_ARGS[@]}" build --pull -t "$DOCKERHUB_DESTINATION" -f "$DOCKERHUB_DOCKEFILE" "$NODE_NAME/$NODE_VERSION"
+          else
+              echo "Skipping linuxarm32v7 because $DOCKERHUB_DOCKEFILE is not found"
+          fi
+
       - name: Publish image
+        if: github.event_name == 'push'
+        env:
+          DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
+          DOCKERHUB_PASS: ${{ secrets.DOCKERHUB_PASS }}
         shell: bash
         run: |
           source ".github/scripts/parse-tag.sh"
@@ -65,7 +119,33 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Build image
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        run: |
+          source ".github/scripts/parse-tag.sh"
+          DOCKER_ARGS=()
+          if [ -n "$DOCKER_OPTIONS" ]; then
+              DOCKER_ARGS=("$DOCKER_OPTIONS")
+          fi
+          DOCKERHUB_DOCKEFILE="$DOCKERHUB_DOCKEFILE_ARM64"
+          DOCKERHUB_DESTINATION="$DOCKERHUB_REPO:$LATEST_TAG-arm64v8"
+          if [ -f "$DOCKERHUB_DOCKEFILE" ]; then
+              sudo docker "${DOCKER_ARGS[@]}" run --rm --privileged multiarch/qemu-user-static:register --reset
+              sudo apt update
+              sudo apt install -y qemu-user-static qemu-user binfmt-support
+              sudo cp /usr/bin/qemu-aarch64-static "$(dirname "$DOCKERHUB_DOCKEFILE")/qemu-aarch64-static"
+              sed -i -e 's/#EnableQEMU //g' "$DOCKERHUB_DOCKEFILE"
+              sudo docker "${DOCKER_ARGS[@]}" build --pull -t "$DOCKERHUB_DESTINATION" -f "$DOCKERHUB_DOCKEFILE" "$NODE_NAME/$NODE_VERSION"
+          else
+              echo "Skipping linuxarm64v8 because $DOCKERHUB_DOCKEFILE is not found"
+          fi
+
       - name: Publish image
+        if: github.event_name == 'push'
+        env:
+          DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
+          DOCKERHUB_PASS: ${{ secrets.DOCKERHUB_PASS }}
         shell: bash
         run: |
           source ".github/scripts/parse-tag.sh"
@@ -92,7 +172,32 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        if: github.event_name == 'workflow_dispatch'
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        if: github.event_name == 'workflow_dispatch'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        run: |
+          source ".github/scripts/parse-tag.sh"
+          DOCKERHUB_DOCKEFILE="$DOCKERHUB_DOCKEFILE_BUILDX"
+          DOCKERHUB_DESTINATION="$DOCKERHUB_REPO:$LATEST_TAG"
+          if [ -f "$DOCKERHUB_DOCKEFILE" ]; then
+              docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -f "$DOCKERHUB_DOCKEFILE" -t "$DOCKERHUB_DESTINATION" "$NODE_NAME/$NODE_VERSION"
+          else
+              echo "Skipping buildx because $DOCKERHUB_DOCKEFILE_BUILDX is not found"
+          fi
+
       - name: Publish image
+        if: github.event_name == 'push'
+        env:
+          DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
+          DOCKERHUB_PASS: ${{ secrets.DOCKERHUB_PASS }}
         shell: bash
         run: |
           source ".github/scripts/parse-tag.sh"
@@ -106,6 +211,7 @@ jobs:
 
   publish_multiarch:
     name: Publish multi-arch manifest
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     needs:
       - publish_linuxamd64
@@ -116,6 +222,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Publish manifest
+        env:
+          DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
+          DOCKERHUB_PASS: ${{ secrets.DOCKERHUB_PASS }}
         shell: bash
         run: |
           source ".github/scripts/parse-tag.sh"


### PR DESCRIPTION
## Overview

This adds a safe way to validate Docker image changes in GitHub Actions before a dependency PR is reviewed, without publishing images or exposing Docker Hub credentials to the build-only path.

## Behavior

- Manual `workflow_dispatch` runs accept a `Project/version` tag and build every Dockerfile available for that version.
- Build-only runs skip Docker Hub login, image pushes, and multi-architecture manifest publication.
- Release tag pushes retain the existing build-and-push behavior and receive Docker Hub credentials only in publishing steps.
- Run titles identify the selected tag and mode, for example `Cloudflared/2024.8.2-4 (Build Only)` or `Tor/0.4.9.11 (Build and Push)`.

## Implementation

- Use one matrix job for amd64, arm/v7, arm64, and buildx images.
- Move image and manifest shell logic out of `publish.yml` into executable scripts under `.github/scripts/`.
- Include the selected tag and platform in each matrix job name.

## Validation

- [Cloudflared build-only run](https://github.com/btcpayserver/dockerfile-deps/actions/runs/33485444583) completed successfully.
- The buildx image was built, architecture-specific jobs skipped their missing Dockerfiles, every publish step was skipped, and the manifest job was skipped.