### PR TITLE
Bump Litecoin Core to 0.21.5.6

### DIFF
--- a/Litecoin/0.21.5.6/docker-entrypoint.sh
+++ b/Litecoin/0.21.5.6/docker-entrypoint.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -e
+
+if [[ "$1" == "litecoin-cli" || "$1" == "litecoin-tx" || "$1" == "litecoind" || "$1" == "test_litecoin" ]]; then
+	mkdir -p "$BITCOIN_DATA"
+
+	CONFIG_PREFIX=""
+	if [[ "${BITCOIN_NETWORK}" == "regtest" ]]; then
+		CONFIG_PREFIX=$'regtest=1\n[regtest]'
+	fi
+	if [[ "${BITCOIN_NETWORK}" == "testnet" ]]; then
+		CONFIG_PREFIX=$'testnet=1\n[test]'
+	fi
+	if [[ "${BITCOIN_NETWORK}" == "mainnet" ]]; then
+		CONFIG_PREFIX=$'mainnet=1\n[main]'
+	fi
+
+	if [[ "$BITCOIN_WALLETDIR" ]] && [[ "$BITCOIN_NETWORK" ]]; then
+		NL=$'\n'
+		WALLETDIR="$BITCOIN_WALLETDIR/${BITCOIN_NETWORK}"
+		WALLETFILE="${WALLETDIR}/wallet.dat"
+		mkdir -p "$WALLETDIR"
+		chown -R bitcoin:bitcoin "$WALLETDIR"
+		CONFIG_PREFIX="${CONFIG_PREFIX}${NL}walletdir=${WALLETDIR}${NL}"
+		if ! [[ -f "${WALLETFILE}" ]]; then
+		  echo "The wallet does not exists, creating it at ${WALLETDIR}..."
+		  gosu bitcoin litecoin-wallet "-datadir=${WALLETDIR}" "-wallet=" create
+		fi
+	fi
+
+	cat <<-EOF > "$BITCOIN_DATA/litecoin.conf"
+	${CONFIG_PREFIX}
+	printtoconsole=1
+	rpcallowip=::/0
+	${BITCOIN_EXTRA_ARGS}
+	EOF
+	chown bitcoin:bitcoin "$BITCOIN_DATA/litecoin.conf"
+
+	if [[ "${BITCOIN_TORCONTROL}" ]]; then
+		# Because bitcoind only accept torcontrol= host as an ip only, we resolve it here and add to config
+		TOR_CONTROL_HOST=$(echo ${BITCOIN_TORCONTROL} | cut -d ':' -f 1)
+		TOR_CONTROL_PORT=$(echo ${BITCOIN_TORCONTROL} | cut -d ':' -f 2)
+		if [[ "$TOR_CONTROL_HOST" ]] && [[ "$TOR_CONTROL_PORT" ]]; then
+			TOR_IP=$(getent hosts $TOR_CONTROL_HOST | cut -d ' ' -f 1)
+			echo "torcontrol=$TOR_IP:$TOR_CONTROL_PORT" >> "$BITCOIN_DATA/litecoin.conf"
+			echo "Added "torcontrol=$TOR_IP:$TOR_CONTROL_PORT" to $BITCOIN_DATA/litecoin.conf"
+		else
+			echo "Invalid BITCOIN_TORCONTROL"
+		fi
+	fi
+
+	# ensure correct ownership and linking of data directory
+	# we do not update group ownership here, in case users want to mount
+	# a host directory and still retain access to it
+	chown -R bitcoin "$BITCOIN_DATA"
+	ln -sfn "$BITCOIN_DATA" /home/bitcoin/.litecoin
+	chown -h bitcoin:bitcoin /home/bitcoin/.litecoin
+	rm -f /home/bitcoin/.litecoin/settings.json
+	exec gosu bitcoin "$@"
+else
+	exec "$@"
+fi

--- a/Litecoin/0.21.5.6/linuxamd64.Dockerfile
+++ b/Litecoin/0.21.5.6/linuxamd64.Dockerfile
@@ -1,0 +1,42 @@
+FROM debian:bookworm-slim as builder
+
+RUN groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
+
+RUN set -ex \
+	&& apt-get update \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
+	&& rm -rf /var/lib/apt/lists/*
+
+ENV LITECOIN_VERSION 0.21.5.6
+ENV LITECOIN_URL https://download.litecoin.org/litecoin-${LITECOIN_VERSION}/linux/litecoin-${LITECOIN_VERSION}-x86_64-linux-gnu.tar.gz
+ENV LITECOIN_SHA256 3c0a217651a431ef446641669a0b74ce7dbcd9b9ed1a118fc830b8f6779ee83f
+
+# install litecoin binaries
+RUN set -ex \
+	&& cd /tmp \
+	&& wget -qO litecoin.tar.gz "$LITECOIN_URL" \
+	&& echo "$LITECOIN_SHA256 litecoin.tar.gz" | sha256sum -c - \
+	&& mkdir bin \
+	&& tar -xzvf litecoin.tar.gz -C /tmp/bin --strip-components=2 "litecoin-$LITECOIN_VERSION/bin/litecoin-cli" "litecoin-$LITECOIN_VERSION/bin/litecoind" "litecoin-$LITECOIN_VERSION/bin/litecoin-wallet" \
+	&& cd bin \
+	&& wget -qO gosu "https://github.com/tianon/gosu/releases/download/1.19/gosu-amd64" \
+	&& echo "52c8749d0142edd234e9d6bd5237dff2d81e71f43537e2f4f66f75dd4b243dd0 gosu" | sha256sum -c -
+
+FROM debian:bookworm-slim
+COPY --from=builder "/tmp/bin" /usr/local/bin
+
+RUN chmod +x /usr/local/bin/gosu && groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
+
+# create data directory
+ENV BITCOIN_DATA /data
+RUN mkdir "$BITCOIN_DATA" \
+	&& chown -R bitcoin:bitcoin "$BITCOIN_DATA" \
+	&& ln -sfn "$BITCOIN_DATA" /home/bitcoin/.litecoin \
+	&& chown -h bitcoin:bitcoin /home/bitcoin/.litecoin
+VOLUME /data
+
+COPY docker-entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
+EXPOSE 9332 9333 19335 19332 19444 19332
+CMD ["litecoind"]

--- a/Litecoin/0.21.5.6/linuxarm32v7.Dockerfile
+++ b/Litecoin/0.21.5.6/linuxarm32v7.Dockerfile
@@ -1,0 +1,44 @@
+# Use manifest image which support all architecture
+FROM debian:bookworm-slim as builder
+
+RUN set -ex \
+	&& apt-get update \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu wget qemu-user-static binfmt-support
+
+ENV LITECOIN_VERSION 0.21.5.6
+ENV LITECOIN_URL https://download.litecoin.org/litecoin-${LITECOIN_VERSION}/linux/litecoin-${LITECOIN_VERSION}-arm-linux-gnueabihf.tar.gz
+ENV LITECOIN_SHA256 5b8925e4fd28accfe14d6137cf226dde651b320d65f36f4e9decbcefb2fcae7e
+
+# install litecoin binaries
+RUN set -ex \
+	&& cd /tmp \
+	&& wget -qO litecoin.tar.gz "$LITECOIN_URL" \
+	&& echo "$LITECOIN_SHA256 litecoin.tar.gz" | sha256sum -c - \
+	&& mkdir bin \
+	&& tar -xzvf litecoin.tar.gz -C /tmp/bin --strip-components=2 "litecoin-$LITECOIN_VERSION/bin/litecoin-cli" "litecoin-$LITECOIN_VERSION/bin/litecoind" "litecoin-$LITECOIN_VERSION/bin/litecoin-wallet" \
+	&& cd bin \
+	&& wget -qO gosu "https://github.com/tianon/gosu/releases/download/1.19/gosu-armhf" \
+	&& echo "8457a0bfd28e016c2c7d8ea6e5f7eed1376033ffbd36491bb455094c8b1dc9fd gosu" | sha256sum -c -
+
+# Making sure the builder build an arm image despite being x64
+FROM --platform=arm debian:bookworm-slim
+
+COPY --from=builder "/tmp/bin" /usr/local/bin
+COPY --from=builder /usr/bin/qemu-arm-static /usr/bin/qemu-arm-static
+
+RUN chmod +x /usr/local/bin/gosu && groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
+
+# create data directory
+ENV BITCOIN_DATA /data
+RUN mkdir "$BITCOIN_DATA" \
+	&& chown -R bitcoin:bitcoin "$BITCOIN_DATA" \
+	&& ln -sfn "$BITCOIN_DATA" /home/bitcoin/.litecoin \
+	&& chown -h bitcoin:bitcoin /home/bitcoin/.litecoin
+
+VOLUME /data
+
+COPY docker-entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
+EXPOSE 9332 9333 19335 19332 19444 19332
+CMD ["litecoind"]

--- a/Litecoin/0.21.5.6/linuxarm64v8.Dockerfile
+++ b/Litecoin/0.21.5.6/linuxarm64v8.Dockerfile
@@ -1,0 +1,44 @@
+# Use manifest image which support all architecture
+FROM debian:bookworm-slim as builder
+
+RUN set -ex \
+	&& apt-get update \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu wget qemu-user-static binfmt-support
+
+ENV LITECOIN_VERSION 0.21.5.6
+ENV LITECOIN_URL https://download.litecoin.org/litecoin-${LITECOIN_VERSION}/linux/litecoin-${LITECOIN_VERSION}-aarch64-linux-gnu.tar.gz
+ENV LITECOIN_SHA256 81c3ca2a7fcbccaabaf0a0ea2022f1990787f0cc1937aaad4dcc61d2856799a8
+
+# install litecoin binaries
+RUN set -ex \
+	&& cd /tmp \
+	&& wget -qO litecoin.tar.gz "$LITECOIN_URL" \
+	&& echo "$LITECOIN_SHA256 litecoin.tar.gz" | sha256sum -c - \
+	&& mkdir bin \
+	&& tar -xzvf litecoin.tar.gz -C /tmp/bin --strip-components=2 "litecoin-$LITECOIN_VERSION/bin/litecoin-cli" "litecoin-$LITECOIN_VERSION/bin/litecoind" "litecoin-$LITECOIN_VERSION/bin/litecoin-wallet" \
+	&& cd bin \
+	&& wget -qO gosu "https://github.com/tianon/gosu/releases/download/1.19/gosu-arm64" \
+	&& echo "3a8ef022d82c0bc4a98bcb144e77da714c25fcfa64dccc57f6aba7ae47ff1a44 gosu" | sha256sum -c -
+
+# Making sure the builder build an arm image despite being x64
+FROM --platform=arm64 debian:bookworm-slim
+
+COPY --from=builder "/tmp/bin" /usr/local/bin
+COPY --from=builder /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
+
+RUN chmod +x /usr/local/bin/gosu && groupadd -r bitcoin && useradd -r -m -g bitcoin bitcoin
+
+# create data directory
+ENV BITCOIN_DATA /data
+RUN mkdir "$BITCOIN_DATA" \
+	&& chown -R bitcoin:bitcoin "$BITCOIN_DATA" \
+	&& ln -sfn "$BITCOIN_DATA" /home/bitcoin/.litecoin \
+	&& chown -h bitcoin:bitcoin /home/bitcoin/.litecoin
+
+VOLUME /data
+
+COPY docker-entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
+EXPOSE 9332 9333 19335 19332 19444 19332
+CMD ["litecoind"]


### PR DESCRIPTION
## Summary

- Upgrade Litecoin Core to 0.21.5.6, which strengthens MWEB transaction, block, and P2P-service validation.

## Compatibility

This release introduces a soft-forking MWEB consensus rule at mainnet height 3,154,440. Upstream strongly recommends all users upgrade, particularly miners, pools, and MWEB service operators. See the [0.21.5.6 release notes](https://github.com/litecoin-project/litecoin/releases/tag/v0.21.5.6).
